### PR TITLE
fix tests on 1.6

### DIFF
--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -196,7 +196,7 @@ function _is_decomposable_with_factors(ex)
     # incorrect.
     return _is_complex_expr(ex) && (
         isempty(ex.args) ||
-        (ex.args[1] != :(.+) && ex.args[1] != :(.-))
+        (ex.args[1] != Symbol(".+") && ex.args[1] != Symbol(".-"))
     )
 end
 
@@ -331,7 +331,7 @@ function _rewrite(
                 current_sum === nothing &&
                 isempty(left_factors) &&
                 isempty(right_factors) &&
-                (inner_factor.args[1] == :(.+) || inner_factor.args[1] == :(.-))
+                (inner_factor.args[1] == Symbol(".+") || inner_factor.args[1] == Symbol(".-"))
             )
         )
             # There are three cases here:
@@ -360,13 +360,13 @@ function _rewrite(
                 push!(code.args, new_code)
                 start = 3
             end
-            if inner_factor.args[1] == :- || inner_factor.args[1] == :(.-)
+            if inner_factor.args[1] == :- || inner_factor.args[1] == Symbol(".-")
                 minus = !minus
             end
             vectorized = (
                 vectorized ||
-                inner_factor.args[1] == :(.+) ||
-                inner_factor.args[1] == :(.-)
+                inner_factor.args[1] == Symbol(".+") ||
+                inner_factor.args[1] == Symbol(".-")
             )
             return rewrite_sum(
                 vectorized,

--- a/test/dummy.jl
+++ b/test/dummy.jl
@@ -7,6 +7,7 @@ DummyBigInt(J::UniformScaling) = DummyBigInt(J.λ)
 
 # Broadcast
 Base.ndims(::Type{DummyBigInt}) = 0
+Base.ndims(::DummyBigInt) = 0
 Base.broadcastable(x::DummyBigInt) = Ref(x)
 
 Base.promote_rule(::Type{DummyBigInt}, ::Type{<:Union{Integer, UniformScaling{<:Integer}}}) = DummyBigInt


### PR DESCRIPTION
the parsing of `:(.+)` has changed so use the explicit Symbol constructor instead
also, implement `ndims` for an instance of `DummyBigInt`