### PR TITLE
Only rewrite generator if it is a sum

### DIFF
--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -604,7 +604,8 @@ function _rewrite(
             length(inner_factor.args) >= 2 && (
                 isexpr(inner_factor.args[2], :generator) ||
                 isexpr(inner_factor.args[2], :flatten)
-            )
+            ) &&
+            _is_sum(inner_factor.args[1])
         )
             # A generator statement.
             code = _parse_generator(

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -28,8 +28,6 @@ end
 include("dummy.jl")
 
 function error_test(x, y, z)
-    err = ErrorException("Expected `sum` outside generator expression; got `prod`.")
-    @test_macro_throws err MA.@rewrite(prod(i for i = 1:2))
     # $(:(y[j=1])) does not print the same on Julia v1.3 or Julia 1.4
     err = ErrorException("Unexpected assignment in expression `$(:(y[j=1]))`.")
     @test_macro_throws err MA.@rewrite y[j = 1]

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -93,3 +93,8 @@ using OffsetArrays
         MA.Test.non_array_test(x, OffsetArray(x, -length(x)))
     end
 end
+
+@testset "generator with not sum" begin
+    @test MA.@rewrite(minimum(j^2 for j in 2:3)) == 4
+    @test MA.@rewrite(maximum(j^2 for j in 2:3)) == 9
+end


### PR DESCRIPTION
Closes #43

Easiest solution is just to only apply the rewrite if it is a `sum`.