### PR TITLE
 _iszero -> iszerodefined

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
           - version: '1'
             os: ubuntu-latest
             arch: x64
-          # - version: nightly
-          #   os: ubuntu-latest
-          #   arch: x64
+          - version: nightly
+            os: ubuntu-latest
+            arch: x64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/38789 has been merged, we can now overload a documenter and without underscore `iszerodefined` function instead of the internal `_iszero`.