### PR TITLE
Implement dot_nonrecursive and add fused_map_reduce

### DIFF
--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -25,11 +25,18 @@ add_mul(a, b, c, d, args::Vararg{Any,N}) where {N} = add_mul(a, b, *(c, d, args.
 """
     sub_mul(a, args...)
 
-Return `a + *(args...)`. Note that `sub_mul(a, b, c) = muladd(b, c, a)`.
+Return `a + *(args...)`.
 """
 function sub_mul end
 sub_mul(a, b) = a - b
 sub_mul(a, b, c, args::Vararg{Any,N}) where {N} = a - *(b, c, args...)
+
+"""
+    add_dot(a, args...)
+
+Return `a + dot(args...)`.
+"""
+add_dot(a, b, c, args::Vararg{Any,N}) where {N} = a + LinearAlgebra.dot(b, c, args...)
 
 const AddSubMul = Union{typeof(add_mul),typeof(sub_mul)}
 add_sub_op(::typeof(add_mul)) = +

--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -6,6 +6,8 @@
 
 module MutableArithmetics
 
+import LinearAlgebra
+
 # Performance note:
 # We use `Vararg` instead of splatting `...` as using `where N` forces Julia to
 # specialize in the number of arguments `N`. Otherwise, we get allocations and
@@ -61,7 +63,6 @@ include("shortcuts.jl")
 include("broadcast.jl")
 
 # Implementation of the interface for Base types
-import LinearAlgebra
 const Scaling = Union{Number,LinearAlgebra.UniformScaling}
 scaling_to_number(x::Number) = x
 scaling_to_number(x::LinearAlgebra.UniformScaling) = x.λ

--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -25,7 +25,7 @@ add_mul(a, b, c, d, args::Vararg{Any,N}) where {N} = add_mul(a, b, *(c, d, args.
 """
     sub_mul(a, args...)
 
-Return `a + *(args...)`.
+Return `a - *(args...)`.
 """
 function sub_mul end
 sub_mul(a, b) = a - b

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -472,8 +472,8 @@ end
 
 # For most types, `dot(b, c) = adjoint(b) * c`.
 promote_operation(::typeof(adjoint), a::Type) = a
-function promote_operation(::typeof(add_dot), a::Type, b::Type, c::Type)
-    return promote_operation(add_mul, a, promote_operation(adjoint, b), c)
+function promote_operation(::typeof(LinearAlgebra.dot), b::Type, c::Type)
+    return promote_operation(*, promote_operation(adjoint, b), c)
 end
 function buffer_for(::typeof(add_dot), a::Type, b::Type, c::Type)
     return buffer_for(add_mul, a, promote_operation(adjoint, b), c)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -471,6 +471,10 @@ function buffered_operate_fallback!(
 end
 
 # For most types, `dot(b, c) = adjoint(b) * c`.
+promote_operation(::typeof(adjoint), a::Type) = a
+function promote_operation(::typeof(add_dot), a::Type, b::Type, c::Type)
+    return promote_operation(add_mul, a, promote_operation(adjoint, b), c)
+end
 function buffer_for(::typeof(add_dot), a::Type, b::Type, c::Type)
     return buffer_for(add_mul, a, promote_operation(adjoint, b), c)
 end

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -14,17 +14,18 @@ reduce_op(op::typeof(add_dot)) = +
 neutral_element(::typeof(+), T::Type) = zero(T)
 map_op(::AddSubMul) = *
 map_op(::typeof(add_dot)) = LinearAlgebra.dot
-function promote_map_reduce(op::Function, args...)
+function promote_map_reduce(op::Function, args::Vararg{Any,N}) where {N}
     T = promote_operation(
         op,
         promote_operation(map_op(op), args...),
         args...,
     )
 end
+
 function fused_map_reduce(
-    op::Function,
+    op::F,
     args::Vararg{Any,N},
-) where {N}
+) where {F<:Function,N}
     _same_length(args...)
     T = promote_map_reduce(op, eltype.(args)...)
     accumulator = neutral_element(reduce_op(op), T)

--- a/src/shortcuts.jl
+++ b/src/shortcuts.jl
@@ -59,8 +59,8 @@ function promote_operation(
 )
     return promote_operation(add_sub_op(op), x, y)
 end
-function promote_operation(op::AddSubMul, T::Type, args::Vararg{Type,N}) where {N}
-    return promote_operation(add_sub_op(op), T, promote_operation(*, args...))
+function promote_operation(op::Union{AddSubMul,typeof(add_dot)}, T::Type, args::Vararg{Type,N}) where {N}
+    return promote_operation(reduce_op(op), T, promote_operation(map_op(op), args...))
 end
 
 """

--- a/test/dispatch.jl
+++ b/test/dispatch.jl
@@ -20,5 +20,9 @@ end
 
 @testset "Dispatch tests" begin
     dispatch_tests(BigInt)
-    dispatch_tests(DummyBigInt)
+    if VERSION >= v"1.5"
+        # On `DummyBigInt` allocates more on previous releases of Julia
+        # as it's dynamically allocated
+        dispatch_tests(DummyBigInt)
+    end
 end

--- a/test/dispatch.jl
+++ b/test/dispatch.jl
@@ -1,0 +1,24 @@
+using LinearAlgebra
+
+# Tests that the calls are correctly redirected to the mutable calls
+# by checking allocations
+function dispatch_tests(::Type{T}) where {T}
+    buffer = zero(T)
+    a = one(T)
+    b = one(T)
+    c = one(T)
+    x = convert.(T, [1, 2, 3])
+    # Need to allocate 1 BigInt for the result and one for the buffer
+    alloc_test(() -> MA.fused_map_reduce(MA.add_mul, x, x), 2BIGINT_ALLOC)
+    alloc_test(() -> MA.fused_map_reduce(MA.add_dot, x, x), 2BIGINT_ALLOC)
+    if T <: MA.AbstractMutable
+        alloc_test(() -> x'x, 2BIGINT_ALLOC)
+        alloc_test(() -> transpose(x) * x, 2BIGINT_ALLOC)
+        alloc_test(() -> LinearAlgebra.dot(x, x), 2BIGINT_ALLOC)
+    end
+end
+
+@testset "Dispatch tests" begin
+    dispatch_tests(BigInt)
+    dispatch_tests(DummyBigInt)
+end

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -195,13 +195,9 @@ end
             alloc_test(() -> MA.mutability(C, MA.add_mul, C, A, B), 0)
         end
 
-        # 40 bytes to create the buffer on 64-bit.
-        # 8 bytes in the double for loop. FIXME: figure out why
-        # Half size on 32-bit.
-        n = Sys.WORD_SIZE == 64 ? 48 : 24
-        alloc_test(() -> MA.add_mul!(C, A, B), n)
-        alloc_test(() -> MA.operate!(MA.add_mul, C, A, B), n)
-        alloc_test(() -> MA.mutable_operate!(MA.add_mul, C, A, B), n)
+        alloc_test(() -> MA.add_mul!(C, A, B), BIGINT_ALLOC)
+        alloc_test(() -> MA.operate!(MA.add_mul, C, A, B), BIGINT_ALLOC)
+        alloc_test(() -> MA.mutable_operate!(MA.add_mul, C, A, B), BIGINT_ALLOC)
     end
 end
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -76,7 +76,7 @@ end
         x = ones(1)
         y = ones(2)
         err = DimensionMismatch(
-            "first array has length 1 which does not match the length of the second, 2.",
+            "one array has length 1 which does not match the length of the next one, 2.",
         )
         @test_throws err MA.operate(*, x', y)
         @test_throws err MA.operate(*, LinearAlgebra.transpose(x), y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,5 +19,6 @@ end
     include("broadcast.jl")
 end
 include("matmul.jl")
+include("dispatch.jl")
 include("rewrite.jl")
 include("hygiene.jl")

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,3 +1,9 @@
+include("dummy.jl")
+
+# Allocating size for allocating a `BigInt`.
+# Half size on 32-bit.
+const BIGINT_ALLOC = Sys.WORD_SIZE == 64 ? 48 : 24
+
 function alloc_test(f, n)
     f() # compile
     @test n == @allocated f()


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/36679 introduced a new function `_dot_nonrecursive`.
While this function does not exploit mutability, several methods redirect to it so implementing it allows to kill a few birds with one stone.
Our implementation of `dot` wasn't really correct since we didn't call `dot` recursively so this PR also fixes that.