### PR TITLE
Remove allocation in broadcast

### DIFF
--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -8,8 +8,12 @@ const MA = MutableArithmetics
     c = [3, 4]
     @test MA.broadcast!(+, a, b) == [4, 5]
     @test a == [4, 5]
-    alloc_test(() -> MA.broadcast!(+, a, b), 0)
-    alloc_test(() -> MA.broadcast!(+, a, c), 0)
+    # Need to have immutable structs that contain references to be allocated on
+    # the stack: https://github.com/JuliaLang/julia/pull/33886
+    if VERSION >= v"1.5"
+        alloc_test(() -> MA.broadcast!(+, a, b), 0)
+        alloc_test(() -> MA.broadcast!(+, a, c), 0)
+    end
 end
 @testset "BigInt" begin
     x = BigInt(1)
@@ -21,8 +25,10 @@ end
     @test a == [4, 5]
     @test x == 4
     @test y == 5
-    # FIXME This should not allocate but I couldn't figure out where these
-    #       240 come from.
-    alloc_test(() -> MA.broadcast!(+, a, b), 240)
-    alloc_test(() -> MA.broadcast!(+, a, c), 0)
+    if VERSION >= v"1.5"
+        # FIXME This should not allocate but I couldn't figure out where these
+        #       240 come from.
+        alloc_test(() -> MA.broadcast!(+, a, b), 240)
+        alloc_test(() -> MA.broadcast!(+, a, c), 0)
+    end
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -5,16 +5,24 @@ const MA = MutableArithmetics
 @testset "Int" begin
     a = [1, 2]
     b = 3
+    c = [3, 4]
     @test MA.broadcast!(+, a, b) == [4, 5]
     @test a == [4, 5]
+    alloc_test(() -> MA.broadcast!(+, a, b), 0)
+    alloc_test(() -> MA.broadcast!(+, a, c), 0)
 end
 @testset "BigInt" begin
     x = BigInt(1)
     y = BigInt(2)
     a = [x, y]
     b = 3
+    c = [2x, 3y]
     @test MA.broadcast!(+, a, b) == [4, 5]
     @test a == [4, 5]
     @test x == 4
     @test y == 5
+    # FIXME This should not allocate but I couldn't figure out where these
+    #       240 come from.
+    alloc_test(() -> MA.broadcast!(+, a, b), 240)
+    alloc_test(() -> MA.broadcast!(+, a, c), 0)
 end


### PR DESCRIPTION
Consider the function:
```julia                                                                                                                                      
function f()                                                                                                                               
    a = [1, 2]
    b = [3, 4]
    @time MA.broadcast!(+, a, b)
end
```
On Julia v1.6.1, before this PR, I get `(8 allocations: 304 bytes)` and after I get no allocations.

There is still some allocations for some other case (see the tests) but I could not figure out where it comes from (similarly to https://github.com/jump-dev/MathOptInterface.jl/issues/1353 where I couldn't figure out either). I may be missing something.