### PR TITLE
Fix ambiguity of / with MOI

### DIFF
--- a/src/shortcuts.jl
+++ b/src/shortcuts.jl
@@ -61,21 +61,6 @@ Return the `gcd` of `a`, `b`, ..., possibly modifying `a`.
 """
 gcd!(args::Vararg{Any,N}) where {N} = operate!(gcd, args...)
 
-# `Vararg` gives extra allocations on Julia v1.3, see https://travis-ci.com/jump-dev/MutableArithmetics.jl/jobs/260666164#L215-L238
-function promote_operation(op::AddSubMul, T::Type, x::Type, y::Type)
-    return promote_operation(add_sub_op(op), T, promote_operation(*, x, y))
-end
-function promote_operation(
-    op::AddSubMul,
-    x::Type{<:AbstractArray},
-    y::Type{<:AbstractArray},
-)
-    return promote_operation(add_sub_op(op), x, y)
-end
-function promote_operation(op::Union{AddSubMul,typeof(add_dot)}, T::Type, args::Vararg{Type,N}) where {N}
-    return promote_operation(reduce_op(op), T, promote_operation(map_op(op), args...))
-end
-
 """
     add_mul_to!(output, args...)
 

--- a/test/int.jl
+++ b/test/int.jl
@@ -13,14 +13,16 @@ const MA = MutableArithmetics
     @test MA.promote_operation(gcd, Int, Int) == Int
     @test MA.promote_operation(gcd, Int, Int, Int) == Int
     @test MA.promote_operation(MA.add_mul, Int, Int, Int) == Int
-    err = ErrorException(
-        "Operation `+` between `$(Array{Int,1})` and `$Int` is not allowed. You should use broadcast.",
-    )
-    @test_throws err MA.promote_operation(+, Vector{Int}, Int)
-    err = ErrorException(
-        "Operation `+` between `$Int` and `$(Array{Int,1})` is not allowed. You should use broadcast.",
-    )
-    @test_throws err MA.promote_operation(+, Int, Vector{Int})
+    for op in [+, -, MA.add_mul, MA.sub_mul]
+        err = ErrorException(
+            "Operation `$op` between `$(Vector{Int})` and `$Int` is not allowed. You should use broadcast.",
+        )
+        @test_throws err MA.promote_operation(op, Vector{Int}, Int)
+        err = ErrorException(
+            "Operation `$op` between `$Int` and `$(Vector{Int})` is not allowed. You should use broadcast.",
+        )
+        @test_throws err MA.promote_operation(op, Int, Vector{Int})
+    end
 end
 @testset "add_to! / add!" begin
     @test MA.mutability(Int, MA.add_to!, Int, Int) isa MA.NotMutable

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -5,10 +5,14 @@ const MA = MutableArithmetics
 struct DummyMutable end
 
 MA.promote_operation(::typeof(+), ::Type{DummyMutable}, ::Type{DummyMutable}) = DummyMutable
+# Test that this does not triggers any ambiguity even if there is a fallback specific to `/`.
+MA.promote_operation(::Union{typeof(-),typeof(/)}, ::Type{DummyMutable}, ::Type{DummyMutable}) = DummyMutable
 MA.mutability(::Type{DummyMutable}) = MA.IsMutable()
 
 @testset "promote_operation" begin
     @test MA.promote_operation(/, Rational{Int}, Rational{Int}) == Rational{Int}
+    @test MA.promote_operation(-, DummyMutable, DummyMutable) == DummyMutable
+    @test MA.promote_operation(/, DummyMutable, DummyMutable) == DummyMutable
 end
 
 @testset "Errors" begin


### PR DESCRIPTION
See https://github.com/jump-dev/SumOfSquares.jl/pull/197/checks?check_run_id=2807131734#step:6:185
Also fixes method ambiguity that prevented the helpful error message to be displayed for https://discourse.julialang.org/t/list-comprehension-of-jump-variables/62848/4.