### PR TITLE
optimize `mutable_copy` on `BigFloat` and `BigInt`

### DIFF
--- a/src/bigfloat.jl
+++ b/src/bigfloat.jl
@@ -1,4 +1,6 @@
 mutability(::Type{BigFloat}) = IsMutable()
+# copied from `deepcopy_internal` implementation in Julia:
+# https://github.com/JuliaLang/julia/blob/7d41d1eb610cad490cbaece8887f9bbd2a775021/base/mpfr.jl#L1041-L1050
 function mutable_copy(x::BigFloat)
     d = x._d
     d′ = GC.@preserve d unsafe_string(pointer(d), sizeof(d)) # creates a definitely-new String

--- a/src/bigfloat.jl
+++ b/src/bigfloat.jl
@@ -1,5 +1,9 @@
 mutability(::Type{BigFloat}) = IsMutable()
-mutable_copy(x::BigFloat) = deepcopy(x)
+function mutable_copy(x::BigFloat)
+    d = x._d
+    d′ = GC.@preserve d unsafe_string(pointer(d), sizeof(d)) # creates a definitely-new String
+    return Base.MPFR._BigFloat(x.prec, x.sign, x.exp, d′)
+end
 
 @static if VERSION >= v"1.1.0-DEV.683"
     const _MPFRRoundingMode = Base.MPFR.MPFRRoundingMode

--- a/src/bigint.jl
+++ b/src/bigint.jl
@@ -1,4 +1,6 @@
 mutability(::Type{BigInt}) = IsMutable()
+# copied from `deepcopy_internal` implementation in Julia:
+# https://github.com/JuliaLang/julia/blob/7d41d1eb610cad490cbaece8887f9bbd2a775021/base/gmp.jl#L772
 mutable_copy(x::BigInt) = Base.GMP.MPZ.set(x)
 
 # zero

--- a/src/bigint.jl
+++ b/src/bigint.jl
@@ -1,5 +1,5 @@
 mutability(::Type{BigInt}) = IsMutable()
-mutable_copy(x::BigInt) = deepcopy(x)
+mutable_copy(x::BigInt) = Base.GMP.MPZ.set(x)
 
 # zero
 promote_operation(::typeof(zero), ::Type{BigInt}) = BigInt


### PR DESCRIPTION
The `deepcopy` in Base creates an `IDDict` to keep track of already copied values:

https://github.com/JuliaLang/julia/blob/60e3e5527f0395d32fe2d59d3eb6c0a5cf59d354/base/deepcopy.jl#L26

However, in our case, this is not needed and we might as well just inline the definition of `deepcopy_internal` without the dictionary. This makes us rely on some of the internals of `MPFR` and `GMP` but this package already does that heavily so might as well go "all in" in that case.

On master the performance is:

```jl
julia> using MutableArithmetics, BenchmarkTools

julia> bf, bi = big"1.0", big"1";

julia> @btime MutableArithmetics.mutable_copy($bf);
  89.067 ns (5 allocations: 464 bytes)

julia> @btime MutableArithmetics.mutable_copy($bi);
  119.106 ns (4 allocations: 376 bytes)
```

while on this PR it is:

```jl
julia> bf, bi = big"1.0", big"1";

julia> @btime MutableArithmetics.mutable_copy($bf);
  18.507 ns (2 allocations: 112 bytes)

julia> @btime MutableArithmetics.mutable_copy($bi);
  63.083 ns (2 allocations: 40 bytes)
```


