### PR TITLE
Workaround for mat_mat_scalar

### DIFF
--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -296,6 +296,24 @@ Base.:*(
     B::StridedMatrix{<:Any},
 ) = mul(A, B)
 
+const StridedMaybeAdjOrTransMat{T} = Union{StridedMatrix{T}, LinearAlgebra.Adjoint{T, <:StridedMatrix}, LinearAlgebra.Transpose{T, <:StridedMatrix}}
+
+# See https://github.com/JuliaLang/julia/pull/37898
+# The default fallback only used `promote_type` so it may get its wrong, e.g., for JuMP and MultivariatePolynomials.
+if VERSION >= v"1.7.0-DEV.1284"
+    _mat_mat_scalar(A, B, γ) = operate!!(*, operate(*, A, B), γ)
+
+    function LinearAlgebra.mat_mat_scalar(A::StridedMaybeAdjOrTransMat{<:AbstractMutable}, B::StridedMaybeAdjOrTransMat, γ)
+        return _mat_mat_scalar(A, B, γ)
+    end
+    function LinearAlgebra.mat_mat_scalar(A::StridedMaybeAdjOrTransMat, B::StridedMaybeAdjOrTransMat{<:AbstractMutable}, γ)
+        return _mat_mat_scalar(A, B, γ)
+    end
+    function LinearAlgebra.mat_mat_scalar(A::StridedMaybeAdjOrTransMat{<:AbstractMutable}, B::StridedMaybeAdjOrTransMat{<:AbstractMutable}, γ)
+        return _mat_mat_scalar(A, B, γ)
+    end
+end
+
 # Base doesn't define efficient fallbacks for sparse array arithmetic involving
 # non-`<:Number` scalar elements, so we define some of these for `<:AbstractMutable` scalar
 # elements here.


### PR DESCRIPTION
`mat_mat_scalar` was added in https://github.com/JuliaLang/julia/pull/37898/ which is included in Julia v1.7.
It uses `promote_type` instead of `Base.promote_op` to determine the type of the resulting array so it won't work for instance when multiplying two matrices of JuMP affine expressions, it won't see that it needs quadratic expressions.