### PR TITLE
Refactor implementations into subdir

### DIFF
--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -67,18 +67,24 @@ include("shortcuts.jl")
 include("broadcast.jl")
 
 # Implementation of the interface for Base types
+
 const Scaling = Union{Number,LinearAlgebra.UniformScaling}
+
 scaling_to_number(x::Number) = x
 scaling_to_number(x::LinearAlgebra.UniformScaling) = x.λ
 scaling(x::Scaling) = x
 scaling_convert(T::Type, x) = convert(T, x)
-# `convert(::Type{<:UniformScaling}, ::UniformScaling)` is not defined in LinearAlgebra.
+
+# `convert(::Type{<:UniformScaling}, ::UniformScaling)` is not defined in
+# LinearAlgebra.
+
 function scaling_convert(
     ::Type{LinearAlgebra.UniformScaling{T}},
     x::LinearAlgebra.UniformScaling,
 ) where {T}
     return LinearAlgebra.UniformScaling(convert(T, x.λ))
 end
+
 function operate(
     ::typeof(convert),
     ::Type{LinearAlgebra.UniformScaling{T}},
@@ -86,14 +92,17 @@ function operate(
 ) where {T}
     return LinearAlgebra.UniformScaling(operate(convert, T, x.λ))
 end
+
 scaling_convert(T::Type, x::LinearAlgebra.UniformScaling) = convert(T, x.λ)
+
 function operate(::typeof(convert), T::Type, x::LinearAlgebra.UniformScaling)
     return operate(convert, T, x.λ)
 end
 
-include("bigint.jl")
-include("bigfloat.jl")
-include("rational.jl")
+include("implementations/BigInt.jl")
+include("implementations/BigFloat.jl")
+include("implementations/Rational.jl")
+include("implementations/MutatingStepRange.jl")
 
 include("reduce.jl")
 include("linear_algebra.jl")
@@ -114,6 +123,7 @@ the equality of the representation is equivalent to the equality of the objects
 begin represented.
 """
 isequal_canonical(a, b) = a == b
+
 function isequal_canonical(
     a::AT,
     b::AT,
@@ -129,18 +139,22 @@ function isequal_canonical(
         return isequal_canonical(elements...)
     end
 end
+
 function isequal_canonical(x::LinearAlgebra.Adjoint, y::LinearAlgebra.Adjoint)
     return isequal_canonical(parent(x), parent(y))
 end
+
 function isequal_canonical(
     x::LinearAlgebra.Transpose,
     y::LinearAlgebra.Transpose,
 )
     return isequal_canonical(parent(x), parent(y))
 end
+
 function isequal_canonical(x::LinearAlgebra.Diagonal, y::LinearAlgebra.Diagonal)
     return isequal_canonical(parent(x), parent(y))
 end
+
 function isequal_canonical(
     x::LinearAlgebra.Tridiagonal,
     y::LinearAlgebra.Tridiagonal,
@@ -149,6 +163,7 @@ function isequal_canonical(
            isequal_canonical(x.d, y.d) &&
            isequal_canonical(x.du, y.du)
 end
+
 function isequal_canonical(x::_SparseMat, y::_SparseMat)
     return x.m == y.m &&
            x.n == y.n &&
@@ -159,7 +174,6 @@ end
 
 include("rewrite.jl")
 include("dispatch.jl")
-include("range.jl")
 
 # Test that can be used to test an implementation of the interface
 include("Test/Test.jl")

--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -7,6 +7,7 @@
 module MutableArithmetics
 
 import LinearAlgebra
+import SparseArrays
 
 # Performance note:
 # We use `Vararg` instead of splatting `...` as using `where N` forces Julia to
@@ -101,12 +102,12 @@ end
 
 include("implementations/BigInt.jl")
 include("implementations/BigFloat.jl")
-include("implementations/Rational.jl")
+include("implementations/LinearAlgebra.jl")
 include("implementations/MutatingStepRange.jl")
+include("implementations/Rational.jl")
+include("implementations/SparseArrays.jl")
 
 include("reduce.jl")
-include("linear_algebra.jl")
-include("sparse_arrays.jl")
 
 """
     isequal_canonical(a, b)

--- a/src/implementations/BigFloat.jl
+++ b/src/implementations/BigFloat.jl
@@ -1,3 +1,6 @@
+# This file contains methods to implement the MutableArithmetics API for
+# Base.BigFloat.
+
 mutability(::Type{BigFloat}) = IsMutable()
 
 # Copied from `deepcopy_internal` implementation in Julia:

--- a/src/implementations/BigFloat.jl
+++ b/src/implementations/BigFloat.jl
@@ -1,5 +1,6 @@
 mutability(::Type{BigFloat}) = IsMutable()
-# copied from `deepcopy_internal` implementation in Julia:
+
+# Copied from `deepcopy_internal` implementation in Julia:
 # https://github.com/JuliaLang/julia/blob/7d41d1eb610cad490cbaece8887f9bbd2a775021/base/mpfr.jl#L1041-L1050
 function mutable_copy(x::BigFloat)
     d = x._d
@@ -14,7 +15,9 @@ else
 end
 
 # zero
+
 promote_operation(::typeof(zero), ::Type{BigFloat}) = BigFloat
+
 function _set_si!(x::BigFloat, value)
     ccall(
         (:mpfr_set_si, :libmpfr),
@@ -29,11 +32,15 @@ end
 operate!(::typeof(zero), x::BigFloat) = _set_si!(x, 0)
 
 # one
+
 promote_operation(::typeof(one), ::Type{BigFloat}) = BigFloat
+
 operate!(::typeof(one), x::BigFloat) = _set_si!(x, 1)
 
 # +
+
 promote_operation(::typeof(+), ::Vararg{Type{BigFloat},N}) where {N} = BigFloat
+
 function operate_to!(output::BigFloat, ::typeof(+), a::BigFloat, b::BigFloat)
     ccall(
         (:mpfr_add, :libmpfr),
@@ -46,12 +53,11 @@ function operate_to!(output::BigFloat, ::typeof(+), a::BigFloat, b::BigFloat)
     )
     return output
 end
-#function operate_to!(output::BigFloat, op::typeof(+), a::BigFloat, b::LinearAlgebra.UniformScaling)
-#    return operate_to!(output, op, a, b.λ)
-#end
 
 # -
+
 promote_operation(::typeof(-), ::Vararg{Type{BigFloat},N}) where {N} = BigFloat
+
 function operate_to!(output::BigFloat, ::typeof(-), a::BigFloat, b::BigFloat)
     ccall(
         (:mpfr_sub, :libmpfr),
@@ -66,7 +72,9 @@ function operate_to!(output::BigFloat, ::typeof(-), a::BigFloat, b::BigFloat)
 end
 
 # *
+
 promote_operation(::typeof(*), ::Vararg{Type{BigFloat},N}) where {N} = BigFloat
+
 function operate_to!(output::BigFloat, ::typeof(*), a::BigFloat, b::BigFloat)
     ccall(
         (:mpfr_mul, :libmpfr),
@@ -90,13 +98,16 @@ function operate_to!(
     operate_to!(output, op, a, b)
     return operate!(op, output, c...)
 end
+
 function operate!(op::Function, x::BigFloat, args::Vararg{Any,N}) where {N}
     return operate_to!(x, op, x, args...)
 end
 
 # add_mul and sub_mul
+
 # Buffer to hold the product
 buffer_for(::AddSubMul, args::Vararg{Type{BigFloat},N}) where {N} = BigFloat()
+
 function operate_to!(
     output::BigFloat,
     op::AddSubMul,
@@ -120,6 +131,7 @@ function buffered_operate_to!(
     operate_to!(buffer, *, x, y, args...)
     return operate_to!(output, add_sub_op(op), a, buffer)
 end
+
 function buffered_operate!(
     buffer::BigFloat,
     op::AddSubMul,
@@ -138,6 +150,7 @@ function operate_to!(
 ) where {N}
     return operate_to!(output, op, _scaling_to_bigfloat.(args)...)
 end
+
 function operate_to!(
     output::BigFloat,
     op::AddSubMul,
@@ -155,6 +168,7 @@ function operate_to!(
         _scaling_to_bigfloat.(args)...,
     )
 end
+
 # Called for instance if `args` is `(v', v)` for a vector `v`.
 function operate_to!(
     output::BigFloat,

--- a/src/implementations/BigInt.jl
+++ b/src/implementations/BigInt.jl
@@ -1,3 +1,6 @@
+# This file contains methods to implement the MutableArithmetics API for
+# Base.BigInt.
+
 mutability(::Type{BigInt}) = IsMutable()
 
 # Copied from `deepcopy_internal` implementation in Julia:

--- a/src/implementations/BigInt.jl
+++ b/src/implementations/BigInt.jl
@@ -1,50 +1,62 @@
 mutability(::Type{BigInt}) = IsMutable()
-# copied from `deepcopy_internal` implementation in Julia:
+
+# Copied from `deepcopy_internal` implementation in Julia:
 # https://github.com/JuliaLang/julia/blob/7d41d1eb610cad490cbaece8887f9bbd2a775021/base/gmp.jl#L772
 mutable_copy(x::BigInt) = Base.GMP.MPZ.set(x)
 
 # zero
+
 promote_operation(::typeof(zero), ::Type{BigInt}) = BigInt
+
 operate!(::typeof(zero), x::BigInt) = Base.GMP.MPZ.set_si!(x, 0)
 
 # one
+
 promote_operation(::typeof(one), ::Type{BigInt}) = BigInt
+
 operate!(::typeof(one), x::BigInt) = Base.GMP.MPZ.set_si!(x, 1)
 
 # +
+
 promote_operation(::typeof(+), ::Vararg{Type{BigInt},N}) where {N} = BigInt
+
 function operate_to!(output::BigInt, ::typeof(+), a::BigInt, b::BigInt)
     return Base.GMP.MPZ.add!(output, a, b)
 end
-#function operate_to!(output::BigInt, op::typeof(+), a::BigInt, b::LinearAlgebra.UniformScaling)
-#    return operate_to!(output, op, a, b.λ)
-#end
 
 # -
+
 promote_operation(::typeof(-), ::Vararg{Type{BigInt},N}) where {N} = BigInt
+
 function operate_to!(output::BigInt, ::typeof(-), a::BigInt, b::BigInt)
     return Base.GMP.MPZ.sub!(output, a, b)
 end
 
 # *
+
 promote_operation(::typeof(*), ::Vararg{Type{BigInt},N}) where {N} = BigInt
+
 function operate_to!(output::BigInt, ::typeof(*), a::BigInt, b::BigInt)
     return Base.GMP.MPZ.mul!(output, a, b)
 end
 
 # gcd
+
 function promote_operation(
     ::Union{typeof(gcd),typeof(lcm)},
     ::Vararg{Type{BigInt},N},
 ) where {N}
     return BigInt
 end
+
 function operate_to!(output::BigInt, ::typeof(gcd), a::BigInt, b::BigInt)
     return Base.GMP.MPZ.gcd!(output, a, b)
 end
+
 function operate_to!(output::BigInt, ::typeof(lcm), a::BigInt, b::BigInt)
     return Base.GMP.MPZ.lcm!(output, a, b)
 end
+
 function operate_to!(
     output::BigInt,
     op::Union{typeof(gcd),typeof(lcm)},
@@ -66,13 +78,16 @@ function operate_to!(
     operate_to!(output, op, a, b)
     return operate!(op, output, c...)
 end
+
 function operate!(op::Function, x::BigInt, args::Vararg{Any,N}) where {N}
     return operate_to!(x, op, x, args...)
 end
 
 # add_mul and sub_mul
+
 # Buffer to hold the product
 buffer_for(::AddSubMul, args::Vararg{Type{BigInt},N}) where {N} = BigInt()
+
 function operate_to!(
     output::BigInt,
     op::AddSubMul,
@@ -96,6 +111,7 @@ function buffered_operate_to!(
     operate_to!(buffer, *, x, y, args...)
     return operate_to!(output, add_sub_op(op), a, buffer)
 end
+
 function buffered_operate!(
     buffer::BigInt,
     op::AddSubMul,
@@ -108,6 +124,7 @@ end
 function _scaling_to(::Type{T}, x) where {T}
     return convert(T, scaling_to_number(x))
 end
+
 _scaling_to_bigint(x) = _scaling_to(BigInt, x)
 
 function operate_to!(
@@ -117,6 +134,7 @@ function operate_to!(
 ) where {N}
     return operate_to!(output, op, _scaling_to_bigint.(args)...)
 end
+
 function operate_to!(
     output::BigInt,
     op::AddSubMul,
@@ -134,6 +152,7 @@ function operate_to!(
         _scaling_to_bigint.(args)...,
     )
 end
+
 # Called for instance if `args` is `(v', v)` for a vector `v`.
 function operate_to!(
     output::BigInt,

--- a/src/implementations/MutatingStepRange.jl
+++ b/src/implementations/MutatingStepRange.jl
@@ -2,35 +2,40 @@ struct MutatingStepRange{T,S} <: OrdinalRange{T,S}
     start::T
     step::S
     stop::T
-
     function MutatingStepRange{T,S}(start::T, step::S, stop::T) where {T,S}
         return new(start, step, Base.steprange_last(start, step, stop))
     end
 end
+
 function MutatingStepRange(start::T, step::S, stop::T) where {T,S}
     return MutatingStepRange{T,S}(start, step, stop)
 end
+
 Base.step(r::MutatingStepRange) = r.step
+
 function Base.unsafe_length(r::MutatingStepRange)
     n = Integer(div((r.stop - r.start) + r.step, r.step))
     return isempty(r) ? zero(n) : n
 end
+
 Base.length(r::MutatingStepRange) = Base.unsafe_length(r)
+
 function Base.isempty(r::MutatingStepRange)
     return (r.start != r.stop) & ((r.step > zero(r.step)) != (r.stop > r.start))
 end
 
 function Base.iterate(r::MutatingStepRange)
     if isempty(r)
-        return nothing
-    else
-        state = copy_if_mutable(first(r))
-        return (state, state)
+        return
     end
+    state = copy_if_mutable(first(r))
+    return (state, state)
 end
 
 function Base.iterate(r::MutatingStepRange{T}, i) where {T}
-    i == last(r) && return nothing
+    if i == last(r)
+        return
+    end
     next = convert(T, operate!!(+, i, step(r)))
     return (next, next)
 end

--- a/src/implementations/MutatingStepRange.jl
+++ b/src/implementations/MutatingStepRange.jl
@@ -1,3 +1,8 @@
+# This file contains methods to implement the MutableArithmetics API for a new
+# MutatingStepRange type. This feature was originally designed because of a
+# discussion in the julialang/julia issue #39008:
+# https://github.com/JuliaLang/julia/issues/39008
+
 struct MutatingStepRange{T,S} <: OrdinalRange{T,S}
     start::T
     step::S

--- a/src/implementations/Rational.jl
+++ b/src/implementations/Rational.jl
@@ -1,3 +1,6 @@
+# This file contains methods to implement the MutableArithmetics API for
+# Base.Rational{T}.
+
 # `Rational` is a `struct`, not a `mutable struct`, so if `T` is not
 # mutable, we cannot mutate the rational.
 mutability(::Type{Rational{T}}) where {T} = mutability(T)

--- a/src/implementations/Rational.jl
+++ b/src/implementations/Rational.jl
@@ -1,10 +1,13 @@
-# `Rational` is a `struct`, not a `mutable struct` so if `T` is not
+# `Rational` is a `struct`, not a `mutable struct`, so if `T` is not
 # mutable, we cannot mutate the rational.
 mutability(::Type{Rational{T}}) where {T} = mutability(T)
+
 mutable_copy(x::Rational) = Rational(mutable_copy(x.num), mutable_copy(x.den))
 
 # zero
+
 promote_operation(::typeof(zero), ::Type{Rational{T}}) where {T} = Rational{T}
+
 function operate!(::typeof(zero), x::Rational)
     operate!(zero, x.num)
     operate!(one, x.den)
@@ -12,7 +15,9 @@ function operate!(::typeof(zero), x::Rational)
 end
 
 # one
+
 promote_operation(::typeof(one), ::Type{Rational{T}}) where {T} = Rational{T}
+
 function operate!(::typeof(one), x::Rational)
     operate!(one, x.num)
     operate!(one, x.den)
@@ -20,6 +25,7 @@ function operate!(::typeof(one), x::Rational)
 end
 
 # +
+
 function promote_operation(
     ::typeof(+),
     ::Type{Rational{S}},
@@ -27,9 +33,10 @@ function promote_operation(
 ) where {S,T}
     return Rational{promote_sum_mul(S, T)}
 end
+
 function operate_to!(output::Rational, ::typeof(+), x::Rational, y::Rational)
     xd, yd = Base.divgcd(promote(x.den, y.den)...)
-    # TODO Use `checked_mul` and `checked_add` like in Base
+    # TODO: Use `checked_mul` and `checked_add` like in Base
     operate_to!(output.num, *, x.num, yd)
     operate!(add_mul, output.num, y.num, xd)
     operate_to!(output.den, *, x.den, yd)
@@ -37,6 +44,7 @@ function operate_to!(output::Rational, ::typeof(+), x::Rational, y::Rational)
 end
 
 # -
+
 function promote_operation(
     ::typeof(-),
     ::Type{Rational{S}},
@@ -44,9 +52,10 @@ function promote_operation(
 ) where {S,T}
     return Rational{promote_sum_mul(S, T)}
 end
+
 function operate_to!(output::Rational, ::typeof(-), x::Rational, y::Rational)
     xd, yd = Base.divgcd(promote(x.den, y.den)...)
-    # TODO Use `checked_mul` and `checked_sub` like in Base
+    # TODO: Use `checked_mul` and `checked_sub` like in Base
     operate_to!(output.num, *, x.num, yd)
     operate!(sub_mul, output.num, y.num, xd)
     operate_to!(output.den, *, x.den, yd)
@@ -54,6 +63,7 @@ function operate_to!(output::Rational, ::typeof(-), x::Rational, y::Rational)
 end
 
 # *
+
 function promote_operation(
     ::typeof(*),
     ::Type{Rational{S}},
@@ -61,6 +71,7 @@ function promote_operation(
 ) where {S,T}
     return Rational{promote_operation(*, S, T)}
 end
+
 function operate_to!(output::Rational, ::typeof(*), x::Rational, y::Rational)
     xn, yd = Base.divgcd(promote(x.num, y.den)...)
     xd, yn = Base.divgcd(promote(x.den, y.num)...)
@@ -70,6 +81,7 @@ function operate_to!(output::Rational, ::typeof(*), x::Rational, y::Rational)
 end
 
 # gcd
+
 function promote_operation(
     ::Union{typeof(gcd),typeof(lcm)},
     ::Type{Rational{S}},
@@ -77,11 +89,13 @@ function promote_operation(
 ) where {S,T}
     return Rational{promote_operation(gcd, S, T)}
 end
+
 function operate_to!(output::Rational, ::typeof(gcd), a::Rational, b::Rational)
     operate_to!(output.num, gcd, a.num, b.num)
     operate_to!(output.den, lcm, a.den, b.den)
     return output
 end
+
 function operate_to!(output::Rational, ::typeof(lcm), a::Rational, b::Rational)
     operate_to!(output.num, lcm, a.num, b.num)
     operate_to!(output.den, gcd, a.den, b.den)
@@ -98,15 +112,18 @@ function operate_to!(
     operate_to!(output, op, a, b)
     return operate!(op, output, c...)
 end
+
 function operate!(op::Function, x::Rational, args::Vararg{Any,N}) where {N}
     return operate_to!(x, op, x, args...)
 end
 
 # add_mul and sub_mul
+
 # Buffer to hold the product
 function buffer_for(::AddSubMul, args::Vararg{Type{<:Rational},N}) where {N}
     return zero(promote_operation(*, args...))
 end
+
 function operate_to!(
     output::Rational,
     op::AddSubMul,
@@ -131,6 +148,7 @@ function buffered_operate_to!(
     operate_to!(buffer, *, x, y, args...)
     return operate_to!(output, add_sub_op(op), a, buffer)
 end
+
 function buffered_operate!(
     buffer::Rational,
     op::AddSubMul,
@@ -147,6 +165,7 @@ function operate_to!(
 ) where {N}
     return operate_to!(output, op, _scaling_to.(typeof(output), args)...)
 end
+
 function operate_to!(
     output::Rational,
     op::AddSubMul,
@@ -164,6 +183,7 @@ function operate_to!(
         _scaling_to.(typeof(output), args)...,
     )
 end
+
 # Called for instance if `args` is `(v', v)` for a vector `v`.
 function operate_to!(
     output::Rational,


### PR DESCRIPTION
This PR refactors the implementations for specific types into an `/src/implementations` sub-directory to make the code easier to navigate.