### PR TITLE
Fix for StaticArrays in multiplication

### DIFF
--- a/src/implementations/LinearAlgebra.jl
+++ b/src/implementations/LinearAlgebra.jl
@@ -357,6 +357,13 @@ function undef_array(::Type{Array{T,N}}, axes::Vararg{Base.OneTo,N}) where {T,N}
     return Array{T,N}(undef, length.(axes))
 end
 
+# This method is for things like StaticArrays which return something other than
+# Base.OneTo for their axes. It isn't typed because there can be a mix of axes
+# in the call.
+function undef_array(::Type{T}, axes...) where {T}
+    return undef_array(T, convert.(Base.OneTo, axes)...)
+end
+
 # Does what `LinearAlgebra/src/matmul.jl` does for abstract matrices and
 # vectors: estimate the resulting element type, allocate the resulting array but
 # it redirects to `mul_to!` instead of `LinearAlgebra.mul!`.

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -296,3 +296,23 @@ end
     MA.operate!!(MA.add_mul, x, A, y)
     @test x == [13, 13]
 end
+
+struct Issue65Matrix <: AbstractMatrix{Float64}
+    x::Matrix{Float64}
+end
+
+struct Issue65OneTo
+    N::Int
+end
+
+Base.size(x::Issue65Matrix) = size(x.x)
+Base.getindex(x::Issue65Matrix, args...) = getindex(x.x, args...)
+Base.axes(x::Issue65Matrix, n) = Issue65OneTo(size(x.x, n))
+Base.convert(::Type{Base.OneTo}, x::Issue65OneTo) = Base.OneTo(x.N)
+
+@testset "Issue #65" begin
+    x = [1.0 2.0; 3.0 4.0]
+    A = Issue65Matrix(x)
+    @test MA.operate(*, A, x[:, 1]) == x * x[:, 1]
+    @test MA.operate(*, A, x) == x * x
+end


### PR DESCRIPTION
Closes #65 

The original test case:
```Julia
julia> using JuMP, GLPK, StaticArrays

julia> model = Model(GLPK.Optimizer)
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: GLPK

julia> @variable(model, 0 <= x <= 10)
x

julia> @variable(model, -10 <= y <= 3.4);

julia> A = SA[1.2 -2; 3 4]  # a SArray
2×2 SMatrix{2, 2, Float64, 4} with indices SOneTo(2)×SOneTo(2):
 1.2  -2.0
 3.0   4.0

julia> @constraint(model, con, A*[x, y] .<= 0)
2-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
 con : 1.2 x - 2 y ≤ 0.0
 con : 3 x + 4 y ≤ 0.0
```