### PR TITLE
Improve performance of LinearAlgebra.dot

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -58,7 +58,12 @@ end
 
 # `Vararg` gives extra allocations on Julia v1.3, see
 # https://travis-ci.com/jump-dev/MutableArithmetics.jl/jobs/260666164#L215-L238
-function promote_operation_fallback(op::AddSubMul, T::Type, x::Type, y::Type)
+function promote_operation_fallback(
+    op::AddSubMul,
+    ::Type{T},
+    ::Type{x},
+    ::Type{y},
+) where {T,x,y}
     return promote_operation(add_sub_op(op), T, promote_operation(*, x, y))
 end
 
@@ -274,7 +279,7 @@ function mutability(x, op, args::Vararg{Any,N}) where {N}
     return mutability(typeof(x), op, typeof.(args)...)
 end
 
-mutability(::Type) = IsNotMutable()
+mutability(::Type{T}) where {T} = IsNotMutable()
 
 """
     mutable_copy(x)


### PR DESCRIPTION
Closes #132

As I suspected, the cause of #132 is some of the dispatch choices for when Julia specializes.

Before:
```julia
julia> @btime direct(100);
  476.903 ns (3 allocations: 2.67 KiB)

julia> @btime no_rewrite(100);
  19.890 μs (399 allocations: 262.59 KiB)

julia> @btime rewrite(100);
  30.507 μs (9 allocations: 5.14 KiB)

julia> @btime linear_algebra(100);
  96.442 μs (9 allocations: 5.12 KiB)
```
After (incl. https://github.com/jump-dev/MathOptInterface.jl/pull/1731):
```julia
julia> @btime direct(100);
  477.354 ns (3 allocations: 2.67 KiB)

julia> @btime no_rewrite(100);
  19.913 μs (399 allocations: 262.59 KiB)

julia> @btime rewrite(100);
  1.634 μs (9 allocations: 5.14 KiB)

julia> @btime manual(100);
  1.523 μs (9 allocations: 5.12 KiB)

julia> @btime linear_algebra(100);
  1.616 μs (9 allocations: 5.12 KiB)
```

This brings the linear algebra code back in line with manual code. But there's still some other things to investigate.

Code:
```Julia
using Revise

using BenchmarkTools
import LinearAlgebra
import MathOptInterface
import MutableArithmetics

const MOI = MathOptInterface
const MA = MutableArithmetics

function direct(n)
    d = 1.0:n
    x = MOI.VariableIndex.(1:n)
    return MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(d, x), 0.0)
end

function no_rewrite(n)
    d = 1.0:n
    x = MOI.VariableIndex.(1:n)
    return sum(d[i] * x[i] for i in 1:n)
end

function rewrite(n)
    d = 1.0:n
    x = MOI.VariableIndex.(1:n)
    return MA.@rewrite(sum(d[i] * x[i] for i in 1:n))
end

function linear_algebra(n)
    d = 1.0:n
    x = MOI.VariableIndex.(1:n)
    return LinearAlgebra.dot(d, x)
end

@btime direct(100);
@btime no_rewrite(100);
@btime rewrite(100);
@btime linear_algebra(100);
```