### PR TITLE
Prep for v1.0 release and drop support for pre Julia 1.6 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         # MutableArithmetics doesn't have any binary dependencies, so just test
         # on Linux, LTS and current release, 64-bit and 32-bit.
         include:
-          - version: '1.0'
+          - version: '1.6'
             os: ubuntu-latest
             arch: x86
-          - version: '1.0'
+          - version: '1.6'
             os: ubuntu-latest
             arch: x64
           - version: '1'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,8 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          # Build documentation on Julia 1.0
-          version: '1.0'
+          version: '1.6'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MutableArithmetics"
 uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 authors = ["Gilles Peiffer", "Benoît Legat", "Sascha Timme"]
-version = "0.3.3"
+version = "1.0.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -10,7 +10,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 OffsetArrays = "1"
-julia = "1"
+julia = "1.6"
 
 [extras]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"

--- a/src/Test/array.jl
+++ b/src/Test/array.jl
@@ -268,9 +268,7 @@ function non_array_test(x, x2)
                 @test_throws AssertionError diagm(x2)
             else
                 @test MA.isequal_canonical(diagm(0 => x), diagm(0 => x2))
-                if VERSION >= v"1.2"
-                    @test MA.isequal_canonical(diagm(x), diagm(x2))
-                end
+                @test MA.isequal_canonical(diagm(x), diagm(x2))
             end
         end
     end
@@ -295,10 +293,8 @@ function dot_test(x)
     @test_rewrite dot(A, x)
     @test_rewrite dot(x, A)
 
-    if VERSION >= v"1.1"
-        y = repeat(x, outer = (one.(size(x))..., size(x, 1)))
-        @test_rewrite dot(x, _constant(x)) - dot(y, _constant(y))
-    end
+    y = repeat(x, outer = (one.(size(x))..., size(x, 1)))
+    @test_rewrite dot(x, _constant(x)) - dot(y, _constant(y))
 end
 
 function sum_test(matrix)

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -26,25 +26,23 @@ end
 
 # TODO: LinearAlgebra should have a documented function so that we don't have to
 # overload an internal function
-if VERSION >= v"1.5.0-rc1.23"
-    function LinearAlgebra._dot_nonrecursive(
-        lhs::AbstractArray{<:AbstractMutable},
-        rhs::AbstractArray,
-    )
-        return fused_map_reduce(add_mul, lhs, rhs)
-    end
-    function LinearAlgebra._dot_nonrecursive(
-        lhs::AbstractArray,
-        rhs::AbstractArray{<:AbstractMutable},
-    )
-        return fused_map_reduce(add_mul, lhs, rhs)
-    end
-    function LinearAlgebra._dot_nonrecursive(
-        lhs::AbstractArray{<:AbstractMutable},
-        rhs::AbstractArray{<:AbstractMutable},
-    )
-        return fused_map_reduce(add_mul, lhs, rhs)
-    end
+function LinearAlgebra._dot_nonrecursive(
+    lhs::AbstractArray{<:AbstractMutable},
+    rhs::AbstractArray,
+)
+    return fused_map_reduce(add_mul, lhs, rhs)
+end
+function LinearAlgebra._dot_nonrecursive(
+    lhs::AbstractArray,
+    rhs::AbstractArray{<:AbstractMutable},
+)
+    return fused_map_reduce(add_mul, lhs, rhs)
+end
+function LinearAlgebra._dot_nonrecursive(
+    lhs::AbstractArray{<:AbstractMutable},
+    rhs::AbstractArray{<:AbstractMutable},
+)
+    return fused_map_reduce(add_mul, lhs, rhs)
 end
 
 function LinearAlgebra.dot(
@@ -72,24 +70,13 @@ end
 # fill!(::Array{AbstractVariableRef}, zero(GenericAffExpr{Float64,eltype(x)}))
 _one_indexed(A) = all(x -> isa(x, Base.OneTo), axes(A))
 
-if VERSION <= v"1.2"
-    function LinearAlgebra.diagm_container(
-        kv::Pair{<:Integer,<:AbstractVector{<:AbstractMutable}}...,
-    )
-        T = promote_type(map(x -> eltype(x.second), kv)...)
-        U = promote_type(T, promote_operation(zero, T))
-        n = mapreduce(x -> length(x.second) + abs(x.first), max, kv)
-        return zeros(U, n, n)
-    end
-else
-    function LinearAlgebra.diagm_container(
-        size,
-        kv::Pair{<:Integer,<:AbstractVector{<:AbstractMutable}}...,
-    )
-        T = promote_type(map(x -> promote_type(eltype(x.second)), kv)...)
-        U = promote_type(T, promote_operation(zero, T))
-        return zeros(U, LinearAlgebra.diagm_size(size, kv...)...)
-    end
+function LinearAlgebra.diagm_container(
+    size,
+    kv::Pair{<:Integer,<:AbstractVector{<:AbstractMutable}}...,
+)
+    T = promote_type(map(x -> promote_type(eltype(x.second)), kv)...)
+    U = promote_type(T, promote_operation(zero, T))
+    return zeros(U, LinearAlgebra.diagm_size(size, kv...)...)
 end
 
 function LinearAlgebra.diagm(x::AbstractVector{<:AbstractMutable})

--- a/src/implementations/BigFloat.jl
+++ b/src/implementations/BigFloat.jl
@@ -11,11 +11,7 @@ function mutable_copy(x::BigFloat)
     return Base.MPFR._BigFloat(x.prec, x.sign, x.exp, d′)
 end
 
-@static if VERSION >= v"1.1.0-DEV.683"
-    const _MPFRRoundingMode = Base.MPFR.MPFRRoundingMode
-else
-    const _MPFRRoundingMode = Int32
-end
+const _MPFRRoundingMode = Base.MPFR.MPFRRoundingMode
 
 # zero
 

--- a/test/big.jl
+++ b/test/big.jl
@@ -20,7 +20,7 @@ end
         allocation_test(*, T, MA.mul!!, MA.mul_to!!, T <: Rational ? 240 : 0)
         # Requires https://github.com/JuliaLang/julia/commit/3f92832df042198b2daefc1f7ca609db38cb8173
         # for `gcd` to be defined on `Rational`.
-        if T == BigInt || (T == Rational{BigInt} && VERSION >= v"1.4.0-DEV.606")
+        if T == BigInt || T == Rational{BigInt}
             allocation_test(gcd, T, MA.gcd!!, MA.gcd_to!!, 0)
             allocation_test(lcm, T, MA.lcm!!, MA.lcm_to!!, 0)
         end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -25,6 +25,6 @@ end
     @test y == 5
     # FIXME This should not allocate but I couldn't figure out where these
     #       240 come from.
-    alloc_test(() -> MA.broadcast!!(+, a, b), 240)
+    alloc_test(() -> MA.broadcast!!(+, a, b), 30 * sizeof(Int))
     alloc_test(() -> MA.broadcast!!(+, a, c), 0)
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -10,10 +10,8 @@ const MA = MutableArithmetics
     @test a == [4, 5]
     # Need to have immutable structs that contain references to be allocated on
     # the stack: https://github.com/JuliaLang/julia/pull/33886
-    if VERSION >= v"1.5"
-        alloc_test(() -> MA.broadcast!!(+, a, b), 0)
-        alloc_test(() -> MA.broadcast!!(+, a, c), 0)
-    end
+    alloc_test(() -> MA.broadcast!!(+, a, b), 0)
+    alloc_test(() -> MA.broadcast!!(+, a, c), 0)
 end
 @testset "BigInt" begin
     x = BigInt(1)
@@ -25,10 +23,8 @@ end
     @test a == [4, 5]
     @test x == 4
     @test y == 5
-    if VERSION >= v"1.5"
-        # FIXME This should not allocate but I couldn't figure out where these
-        #       240 come from.
-        alloc_test(() -> MA.broadcast!!(+, a, b), 240)
-        alloc_test(() -> MA.broadcast!!(+, a, c), 0)
-    end
+    # FIXME This should not allocate but I couldn't figure out where these
+    #       240 come from.
+    alloc_test(() -> MA.broadcast!!(+, a, b), 240)
+    alloc_test(() -> MA.broadcast!!(+, a, c), 0)
 end

--- a/test/dispatch.jl
+++ b/test/dispatch.jl
@@ -20,9 +20,7 @@ end
 
 @testset "Dispatch tests" begin
     dispatch_tests(BigInt)
-    if VERSION >= v"1.5"
-        # On `DummyBigInt` allocates more on previous releases of Julia
-        # as it's dynamically allocated
-        dispatch_tests(DummyBigInt)
-    end
+    # On `DummyBigInt` allocates more on previous releases of Julia
+    # as it's dynamically allocated
+    dispatch_tests(DummyBigInt)
 end

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -63,7 +63,7 @@ const EXPECTED_ERROR = string(
     "`Matrix{NoProdMutable}` because the sum of the product of a ",
     "`NoProdMutable` and a `NoProdMutable` could not be inferred so a ",
     "`Matrix{Union{}}` allocated to store the output of the ",
-    "multiplication instead of a `Matrix{Int64}`.",
+    "multiplication instead of a `Matrix{$(Int)}`.",
 )
 
 struct NoProdMutable <: MA.AbstractMutable end

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -67,17 +67,12 @@ const EXPECTED_ERROR = string(
 )
 
 struct NoProdMutable <: MA.AbstractMutable end
-@static if VERSION < v"1.6"
-    # Hack for making the test work on old Julia versions
-    Base.:*(::NoProdMutable, ::NoProdMutable) = error(EXPECTED_ERROR)
-else
-    function MA.promote_operation(
-        ::typeof(*),
-        ::Type{NoProdMutable},
-        ::Type{NoProdMutable},
-    )
-        return Int # Dummy result just to test error message
-    end
+function MA.promote_operation(
+    ::typeof(*),
+    ::Type{NoProdMutable},
+    ::Type{NoProdMutable},
+)
+    return Int # Dummy result just to test error message
 end
 
 function unsupported_product()
@@ -99,14 +94,9 @@ end
     @testset "Dimension mismatch" begin
         A = zeros(1, 1)
         B = zeros(2, 2)
-        # Changed by https://github.com/JuliaLang/julia/pull/33567
-        if VERSION >= v"1.4.0-DEV.307"
-            err = DimensionMismatch(
-                "dimensions must match: a has dims (Base.OneTo(1), Base.OneTo(1)), b has dims (Base.OneTo(2), Base.OneTo(2)), mismatch at 1",
-            )
-        else
-            err = DimensionMismatch("dimensions must match")
-        end
+        err = DimensionMismatch(
+            "dimensions must match: a has dims (Base.OneTo(1), Base.OneTo(1)), b has dims (Base.OneTo(2), Base.OneTo(2)), mismatch at 1",
+        )
         @test_throws err MA.@rewrite A + B
         x = ones(1)
         y = ones(2)


### PR DESCRIPTION
I think it makes sense at this point to drop support for Julia <1.6 in all v1.0 releases in JuMP-dev.