### PR TITLE
Add license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Gilles Peiffer, Benoît Legat, Sascha Timme
+Copyright (c) 2019 MutableArithmetics.jl contributors
 
 Mozilla Public License, version 2.0
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 using Documenter, MutableArithmetics
 
 makedocs(;

--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -1,8 +1,8 @@
-#  Copyright 2019, Gilles Peiffer, Benoît Legat, Sascha Timme, and contributors
-#  This Source Code Form is subject to the terms of the Mozilla Public
-#  License, v. 2.0. If a copy of the MPL was not distributed with this
-#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#############################################################################
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
 
 module MutableArithmetics
 

--- a/src/Test/Test.jl
+++ b/src/Test/Test.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 module Test
 
 import MutableArithmetics

--- a/src/Test/array.jl
+++ b/src/Test/array.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 function matrix_vector_division_test(x)
     if size(x) == (3, 3)
         A = [

--- a/src/Test/config.jl
+++ b/src/Test/config.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 macro test_suite(setname, subsets = false)
     testname = Symbol(string(setname) * "_test")
     testdict = Symbol(string(testname) * "s")

--- a/src/Test/generic.jl
+++ b/src/Test/generic.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 #!format:off
 # TODO(odow): JuliaFormatter cannot format this file for some reason?
 

--- a/src/Test/int.jl
+++ b/src/Test/int.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 function int_add_test(::Type{T}) where {T}
     @testset "add_to! / add!" begin
         @test MA.mutability(T, +, T, T) isa MA.IsMutable

--- a/src/Test/quadratic.jl
+++ b/src/Test/quadratic.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 function quadratic_division_test(w, x, y, z)
     @test_rewrite w / 2
     a = 7

--- a/src/Test/scalar.jl
+++ b/src/Test/scalar.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 function iszero_test(x)
     x_copy = x
 

--- a/src/Test/sparse.jl
+++ b/src/Test/sparse.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 function _mat_mat_test(A, B)
     @test _matrix_equal(copy(transpose(A)) * B, A' * B)
     @test _matrix_equal(A * copy(transpose(B)), A * B')

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 # This file provides a mutable broadcast interface for types that support
 # mutation.
 

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 # TODO: this file contains a large number of method specializations to intercept
 # "externally owned" method calls by dispatching on type parameters (rather than
 # outermost wrapper type). This is generally bad practice, but refactoring this

--- a/src/implementations/BigFloat.jl
+++ b/src/implementations/BigFloat.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 # This file contains methods to implement the MutableArithmetics API for
 # Base.BigFloat.
 

--- a/src/implementations/BigInt.jl
+++ b/src/implementations/BigInt.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 # This file contains methods to implement the MutableArithmetics API for
 # Base.BigInt.
 

--- a/src/implementations/LinearAlgebra.jl
+++ b/src/implementations/LinearAlgebra.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 # This file contains methods to implement the MutableArithmetics API for types
 # in the LinearAlgebra stdlib.
 

--- a/src/implementations/MutatingStepRange.jl
+++ b/src/implementations/MutatingStepRange.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 # This file contains methods to implement the MutableArithmetics API for a new
 # MutatingStepRange type. This feature was originally designed because of a
 # discussion in the julialang/julia issue #39008:

--- a/src/implementations/Rational.jl
+++ b/src/implementations/Rational.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 # This file contains methods to implement the MutableArithmetics API for
 # Base.Rational{T}.
 

--- a/src/implementations/SparseArrays.jl
+++ b/src/implementations/SparseArrays.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 # This file contains methods to implement the MutableArithmetics API for types
 # in the SparseArrays stdlib.
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 # Example of mutable types that can implement this API: BigInt, Array, JuMP.AffExpr, MultivariatePolynomials.AbstractPolynomial
 # `operate!(add_mul, ...)` is similar to `JuMP.add_to_expression(...)`
 # `operate!!(add_mul, ...)` is similar to `JuMP.destructive_add(...)`

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 _check_same_length(::Any) = nothing
 
 function _check_same_length(a, b, c::Vararg{Any,N}) where {N}

--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 """
     @rewrite(expr)
 

--- a/src/shortcuts.jl
+++ b/src/shortcuts.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 """
     add_to!!(a, b, c)
 

--- a/test/big.jl
+++ b/test/big.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 function allocation_test(op, T, short, short_to, n)
     a = T(2)
     b = T(3)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 using Test
 import MutableArithmetics
 const MA = MutableArithmetics

--- a/test/dispatch.jl
+++ b/test/dispatch.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 using LinearAlgebra
 
 # Tests that the calls are correctly redirected to the mutable calls

--- a/test/dummy.jl
+++ b/test/dummy.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 using LinearAlgebra
 import MutableArithmetics
 const MA = MutableArithmetics

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 # hygiene.jl
 # Make sure that our macros have good hygiene
 

--- a/test/int.jl
+++ b/test/int.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 using Test
 import MutableArithmetics
 const MA = MutableArithmetics

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 using Test
 import MutableArithmetics
 const MA = MutableArithmetics

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 using Test
 import MutableArithmetics
 const MA = MutableArithmetics

--- a/test/range.jl
+++ b/test/range.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 using Test
 import MutableArithmetics
 const MA = MutableArithmetics

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 using LinearAlgebra, SparseArrays, Test
 import MutableArithmetics
 const MA = MutableArithmetics

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 using Test
 import MutableArithmetics
 const MA = MutableArithmetics

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2019 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
 include("dummy.jl")
 
 # Allocating size for allocating a `BigInt`.


### PR DESCRIPTION
cc @saschatimme 
cc @Peiffap 
cc @blegat 

We're standardizing the license headers across JuMP-dev. Since there are more people that have contributed than are listed in the license, your names are being replaced with "MutableArithmetics.jl contributors".

x-ref: https://github.com/jump-dev/AmplNLWriter.jl/pull/155