### PR TITLE
Fix implementation of fused_map_reduce

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -666,6 +666,15 @@ function promote_operation_fallback(
     return promote_operation(*, promote_operation(adjoint, A), B)
 end
 
+function promote_operation_fallback(
+    ::typeof(LinearAlgebra.dot),
+    ::Type{<:AbstractArray{A}},
+    ::Type{<:AbstractArray{B}},
+) where {A,B}
+    C = promote_operation(*, A, B)
+    return promote_operation(+, C, C)
+end
+
 function buffer_for(::typeof(add_dot), a::Type, b::Type, c::Type)
     return buffer_for(add_mul, a, promote_operation(adjoint, b), c)
 end

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -37,7 +37,7 @@ end
 
 function fused_map_reduce(op::F, args::Vararg{Any,N}) where {F<:Function,N}
     _check_same_length(args...)
-    if length(args[1]) == 0
+    if isempty(args[1])
         # If there are no arguments, we need to use the eltype of each vector to
         # infer the result type.
         return _accumulator(eltype, op, args...)

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -26,12 +26,27 @@ map_op(::AddSubMul) = *
 
 map_op(::typeof(add_dot)) = LinearAlgebra.dot
 
+# We need a generated function here to help with type stability.
+@generated function _accumulator(f::F, op::O, args::Vararg{Any,N}) where {F,O,N}
+    expr = Expr(:call, :(map_op(op)))
+    for i in 1:N
+        push!(expr.args, :(zero(f(args[$i]))))
+    end
+    return expr
+end
+
 function fused_map_reduce(op::F, args::Vararg{Any,N}) where {F<:Function,N}
     _check_same_length(args...)
     if length(args[1]) == 0
-        return map_op(op)(zero.(eltype.(args))...)
+        # If there are no arguments, we need to use the eltype of each vector to
+        # infer the result type.
+        return _accumulator(eltype, op, args...)
     end
-    accumulator = map_op(op)(zero.(first.(args))...)
+    # If there are arguments, we use the first element. We don't use the eltype
+    # because non-concrete vectors might have an eltype that isn't amenable to
+    # zero(T). Ideally, this would be an error. But LinearAlgebra.dot supports
+    # it so we do too.
+    accumulator = _accumulator(first, op, args...)
     T = typeof(accumulator)
     buffer = buffer_for(op, T, eltype.(args)...)
     for I in zip(eachindex.(args)...)

--- a/test/dispatch.jl
+++ b/test/dispatch.jl
@@ -9,16 +9,18 @@ using LinearAlgebra
 # Tests that the calls are correctly redirected to the mutable calls
 # by checking allocations
 function dispatch_tests(::Type{T}) where {T}
+    buffer = zero(T)
+    a = one(T)
+    b = one(T)
+    c = one(T)
     x = convert.(T, [1, 2, 3])
-    # Need to allocate 1 BigInt for the result and one for the buffer, plus two
-    # zero(T) for determining the eltype of the result.
-    cost = Sys.WORD_SIZE == 64 ? (2 * 48 + 2 * 40) : (2 * 24 + 2 * 20)
-    alloc_test(() -> MA.fused_map_reduce(MA.add_mul, x, x), cost)
-    alloc_test(() -> MA.fused_map_reduce(MA.add_dot, x, x), cost)
+    # Need to allocate 1 BigInt for the result and one for the buffer
+    alloc_test(() -> MA.fused_map_reduce(MA.add_mul, x, x), 2BIGINT_ALLOC)
+    alloc_test(() -> MA.fused_map_reduce(MA.add_dot, x, x), 2BIGINT_ALLOC)
     if T <: MA.AbstractMutable
-        alloc_test(() -> x'x, cost)
-        alloc_test(() -> transpose(x) * x, cost)
-        alloc_test(() -> LinearAlgebra.dot(x, x), cost)
+        alloc_test(() -> x'x, 2BIGINT_ALLOC)
+        alloc_test(() -> transpose(x) * x, 2BIGINT_ALLOC)
+        alloc_test(() -> LinearAlgebra.dot(x, x), 2BIGINT_ALLOC)
     end
 end
 

--- a/test/dispatch.jl
+++ b/test/dispatch.jl
@@ -9,18 +9,16 @@ using LinearAlgebra
 # Tests that the calls are correctly redirected to the mutable calls
 # by checking allocations
 function dispatch_tests(::Type{T}) where {T}
-    buffer = zero(T)
-    a = one(T)
-    b = one(T)
-    c = one(T)
     x = convert.(T, [1, 2, 3])
-    # Need to allocate 1 BigInt for the result and one for the buffer
-    alloc_test(() -> MA.fused_map_reduce(MA.add_mul, x, x), 2BIGINT_ALLOC)
-    alloc_test(() -> MA.fused_map_reduce(MA.add_dot, x, x), 2BIGINT_ALLOC)
+    # Need to allocate 1 BigInt for the result and one for the buffer, plus two
+    # zero(T) for determining the eltype of the result.
+    cost = Sys.WORD_SIZE == 64 ? (2 * 48 + 2 * 40) : (2 * 24 + 2 * 20)
+    alloc_test(() -> MA.fused_map_reduce(MA.add_mul, x, x), cost)
+    alloc_test(() -> MA.fused_map_reduce(MA.add_dot, x, x), cost)
     if T <: MA.AbstractMutable
-        alloc_test(() -> x'x, 2BIGINT_ALLOC)
-        alloc_test(() -> transpose(x) * x, 2BIGINT_ALLOC)
-        alloc_test(() -> LinearAlgebra.dot(x, x), 2BIGINT_ALLOC)
+        alloc_test(() -> x'x, cost)
+        alloc_test(() -> transpose(x) * x, cost)
+        alloc_test(() -> LinearAlgebra.dot(x, x), cost)
     end
 end
 
@@ -29,4 +27,17 @@ end
     # On `DummyBigInt` allocates more on previous releases of Julia
     # as it's dynamically allocated
     dispatch_tests(DummyBigInt)
+
+    @testset "dot non-concrete vector" begin
+        x = [5.0, 6.0]
+        y = Vector{Union{Float64,String}}(x)
+        @test MA.operate(LinearAlgebra.dot, x, y) == LinearAlgebra.dot(x, y)
+        @test MA.operate(*, x', y) == x' * y
+    end
+
+    @testset "dot vector of vectors" begin
+        x = [5.0, 6.0]
+        z = [x, x]
+        @test MA.operate(LinearAlgebra.dot, z, z) == LinearAlgebra.dot(z, z)
+    end
 end


### PR DESCRIPTION
Closes #92

This results in a few more allocations, but it fixes incorrect behavior.

In particular, `master` currently produces:

```julia
julia> x = [5.0, 6.0]
2-element Vector{Float64}:
 5.0
 6.0

julia> y = Vector{Union{Float64,String}}(x)
2-element Vector{Union{Float64, String}}:
 5.0
 6.0

julia> MA.operate(*, x', y)
ERROR: MethodError: no method matching zero(::Type{Union{Float64, String}})
Closest candidates are:
  zero(::Union{Type{P}, P}) where P<:Dates.Period at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Dates/src/periods.jl:53
  zero(::JuMP.GenericQuadExpr) at /Users/oscar/.julia/packages/JuMP/Z1pVn/src/quad_expr.jl:109
  zero(::JuMP.GenericAffExpr) at /Users/oscar/.julia/packages/JuMP/Z1pVn/src/aff_expr.jl:192
  ...
Stacktrace:
  [1] _instantiate_zero(#unused#::Type{Union{Float64, String}})
    @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/interface.jl:28
  [2] promote_operation_fallback(op::typeof(*), #unused#::Type{Float64}, #unused#::Type{Union{Float64, String}})
    @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/interface.jl:51
  [3] promote_operation(::typeof(*), ::Type, ::Type)
    @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/interface.jl:113
  [4] promote_operation_fallback(#unused#::typeof(LinearAlgebra.dot), #unused#::Type{Float64}, #unused#::Type{Union{Float64, String}})
    @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/interface.jl:666
  [5] promote_operation(::typeof(LinearAlgebra.dot), ::Type, ::Type)
    @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/interface.jl:113
  [6] promote_map_reduce(::Function, ::Type, ::Type)
    @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/reduce.jl:32
  [7] fused_map_reduce(::typeof(MutableArithmetics.add_dot), ::Vector{Float64}, ::Vector{Union{Float64, String}})
    @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/reduce.jl:41
  [8] operate(#unused#::typeof(LinearAlgebra.dot), x::Vector{Float64}, y::Vector{Union{Float64, String}})
    @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/implementations/LinearAlgebra.jl:486
  [9] operate(#unused#::typeof(*), x::LinearAlgebra.Adjoint{Float64, Vector{Float64}}, y::Vector{Union{Float64, String}})
    @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/implementations/LinearAlgebra.jl:459
 [10] top-level scope
    @ REPL[141]:1

julia> z = [x, x]
2-element Vector{Vector{Float64}}:
 [5.0, 6.0]
 [5.0, 6.0]

julia> MA.operate(LinearAlgebra.dot, z, z)
ERROR: MethodError: promote_operation_fallback(::typeof(LinearAlgebra.dot), ::Type{Vector{Float64}}, ::Type{Vector{Float64}}) is ambiguous. Candidates:
  promote_operation_fallback(op::Function, x::Type{var"#s1"} where var"#s1"<:AbstractArray, y::Type{var"#s2"} where var"#s2"<:AbstractArray) in MutableArithmetics at /Users/oscar/.julia/packages/MutableArithmetics/maUDe/src/interface.jl:15
  promote_operation_fallback(::typeof(LinearAlgebra.dot), ::Type{A}, ::Type{B}) where {A, B} in MutableArithmetics at /Users/oscar/.julia/packages/MutableArithmetics/maUDe/src/interface.jl:661
Possible fix, define
  promote_operation_fallback(::typeof(LinearAlgebra.dot), ::Type{A}, ::Type{B}) where {A<:AbstractArray, B<:AbstractArray}
Stacktrace:
 [1] promote_operation(::typeof(LinearAlgebra.dot), ::Type, ::Type)
   @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/interface.jl:113
 [2] promote_map_reduce(::Function, ::Type, ::Type)
   @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/reduce.jl:32
 [3] fused_map_reduce(::typeof(MutableArithmetics.add_dot), ::Vector{Vector{Float64}}, ::Vector{Vector{Float64}})
   @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/reduce.jl:41
 [4] operate(#unused#::typeof(LinearAlgebra.dot), x::Vector{Vector{Float64}}, y::Vector{Vector{Float64}})
   @ MutableArithmetics ~/.julia/packages/MutableArithmetics/maUDe/src/implementations/LinearAlgebra.jl:486
 [5] top-level scope
   @ REPL[143]:1
```