### PR TITLE
Fix promotion fallbacks with non-concrete types

### DIFF
--- a/test/dispatch.jl
+++ b/test/dispatch.jl
@@ -37,6 +37,16 @@ end
         @test MA.operate(*, x', y) == x' * y
     end
 
+    @testset "mult non-concrete vector" begin
+        A = [1 2; 3 4]
+        x = Vector{Union{Float64,String}}([5.0, 6.0])
+        y = Vector{Union{String,Float64}}([5.0, 6.0])
+        @test MA.operate(*, A, x) == A * x
+        @test MA.operate(*, x', A) == x' * A
+        @test MA.operate(*, A, y) == A * y
+        @test MA.operate(*, y', A) == y' * A
+    end
+
     @testset "dot vector of vectors" begin
         x = [5.0, 6.0]
         z = [x, x]


### PR DESCRIPTION
Related to #171.

I don't know about this fix. It feels like a kludge.

The core issue is that `Base` is forgiving about the types of containers in linear algebra. It often just does things based on their run-time value. But because MA tries to pre-allocate things, it guesses what will happen from the eltype, e.g., in `Vector{T}`. The problem is that if `T` is non-concrete a call to `zero` will fail, **even though the vector will probably contain concrete runtime values that support the operation**.