### PR TITLE
0-allocation add_mul for Rational{BigInt}

### DIFF
--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -50,6 +50,8 @@ end
 const AddSubMul = Union{typeof(add_mul),typeof(sub_mul)}
 add_sub_op(::typeof(add_mul)) = +
 add_sub_op(::typeof(sub_mul)) = -
+add_sub_mul_op(::typeof(+)) = add_mul
+add_sub_mul_op(::typeof(-)) = sub_mul
 
 """
     iszero!!(x)

--- a/src/Test/int.jl
+++ b/src/Test/int.jl
@@ -76,7 +76,7 @@ function int_add_mul_test(::Type{T}) where {T}
         b = t(9)
         c = t(3)
         d = t(20)
-        buf = t(24)
+        buf = MA.buffer_for(MA.add_mul, typeof(a), typeof(b), typeof(c))
 
         @test MA.isequal_canonical(MA.add_mul_to!!(a, b, c, d), t(69))
         @test MA.isequal_canonical(a, t(69))
@@ -94,7 +94,6 @@ function int_add_mul_test(::Type{T}) where {T}
         b = t(16)
         c = t(17)
         d = t(42)
-        buf = t(56)
         @test MA.isequal_canonical(MA.add_mul!!(a, b, c), t(420))
         @test MA.isequal_canonical(a, t(420))
         a = t(148)

--- a/src/implementations/Rational.jl
+++ b/src/implementations/Rational.jl
@@ -66,7 +66,7 @@ function buffer_for(::Union{typeof(+),typeof(-)}, ::Type{Rational{S}}, ::Type{Ra
     return zero(U), zero(U), zero(U)
 end
 
-function buffered_operate_to!(buffer, output::Rational, op::Union{typeof(-),typeof(+)}, x::Rational, y::Rational)
+function buffered_operate_to!(buffer::Tuple, output::Rational, op::Union{typeof(-),typeof(+)}, x::Rational, y::Rational)
     _buffered_divgcd(buffer[1], x.den, buffer[2], y.den, buffer[3])
     # TODO: Use `checked_mul` and `checked_sub` like in Base
     operate_to!(output.num, *, x.num, buffer[3])
@@ -106,7 +106,7 @@ function buffer_for(::typeof(*), ::Type{Rational{S}}, ::Type{Rational{T}}) where
     return zero(Rational{S}), zero(Rational{T}), zero(U)
 end
 
-function buffered_operate_to!(buffer, output::Rational, ::typeof(*), x::Rational, y::Rational)
+function buffered_operate_to!(buffer::Tuple, output::Rational, ::typeof(*), x::Rational, y::Rational)
     # Cannot use `output.num` and `output.den` as buffer as `output` might be an alias for `x`
     _buffered_divgcd(buffer[3], x.num, buffer[1].num, y.den, buffer[2].den)
     _buffered_divgcd(buffer[3], x.den, buffer[1].den, y.num, buffer[2].num)
@@ -177,7 +177,7 @@ function operate_to!(
 end
 
 function buffered_operate_to!(
-    buffer,
+    buffer::Tuple,
     output::Rational,
     op::AddSubMul,
     a::Rational,

--- a/src/implementations/Rational.jl
+++ b/src/implementations/Rational.jl
@@ -33,22 +33,51 @@ function operate!(::typeof(one), x::Rational)
     return x
 end
 
-# +
+function _buffered_divgcd(buffer, x, x_output, y, y_output)
+    operate_to!(buffer, gcd, x, y)
+    operate_to!(x_output, div, x, buffer)
+    operate_to!(y_output, div, y, buffer)
+    return
+end
+
+function _buffered_divgcd(buffer, x, y)
+    operate_to!(buffer, gcd, x, y)
+    if !isone(buffer)
+        operate!(div, x, buffer)
+        operate!(div, y, buffer)
+    end
+    return
+end
+
+_buffered_simplify(buffer, x::Rational) = _buffered_divgcd(buffer, x.num, x.den)
+
+# + and -
 
 function promote_operation(
-    ::typeof(+),
+    ::Union{typeof(+),typeof(-)},
     ::Type{Rational{S}},
     ::Type{Rational{T}},
 ) where {S,T}
     return Rational{promote_sum_mul(S, T)}
 end
 
-function _buffered_simplify(buffer, x::Rational)
-    operate_to!(buffer, gcd, x.num, x.den)
-    if !isone(buffer)
-        operate!(div, x.num, buffer)
-        operate!(div, x.den, buffer)
-    end
+function buffer_for(::Union{typeof(+),typeof(-)}, ::Type{Rational{S}}, ::Type{Rational{T}}) where {S,T}
+    U = promote_operation(gcd, S, T)
+    return zero(U), zero(U), zero(U)
+end
+
+function buffered_operate_to!(buffer, output::Rational, op::Union{typeof(-),typeof(+)}, x::Rational, y::Rational)
+    _buffered_divgcd(buffer[1], x.den, buffer[2], y.den, buffer[3])
+    # TODO: Use `checked_mul` and `checked_sub` like in Base
+    operate_to!(output.num, *, x.num, buffer[3])
+    buffered_operate!(buffer[2], add_sub_mul_op(op), output.num, y.num, buffer[2])
+    operate_to!(output.den, *, x.den, buffer[3])
+    _buffered_simplify(buffer[1], output)
+    return output
+end
+
+function operate_to!(output::Rational, op::Union{typeof(+),typeof(-)}, x::Rational, y::Rational)
+    return buffered_operate_to!(buffer_for(op, typeof(x), typeof(y)), output, op, x, y)
 end
 
 function operate_to!(output::Rational, ::typeof(+), x::Rational, y::Rational)
@@ -56,27 +85,6 @@ function operate_to!(output::Rational, ::typeof(+), x::Rational, y::Rational)
     # TODO: Use `checked_mul` and `checked_add` like in Base
     operate_to!(output.num, *, x.num, yd)
     operate!(add_mul, output.num, y.num, xd)
-    operate_to!(output.den, *, x.den, yd)
-    # Reuse `xd` as it is a local copy created by this method
-    _buffered_simplify(xd, output)
-    return output
-end
-
-# -
-
-function promote_operation(
-    ::typeof(-),
-    ::Type{Rational{S}},
-    ::Type{Rational{T}},
-) where {S,T}
-    return Rational{promote_sum_mul(S, T)}
-end
-
-function operate_to!(output::Rational, ::typeof(-), x::Rational, y::Rational)
-    xd, yd = Base.divgcd(promote(x.den, y.den)...)
-    # TODO: Use `checked_mul` and `checked_sub` like in Base
-    operate_to!(output.num, *, x.num, yd)
-    operate!(sub_mul, output.num, y.num, xd)
     operate_to!(output.den, *, x.den, yd)
     # Reuse `xd` as it is a local copy created by this method
     _buffered_simplify(xd, output)
@@ -93,12 +101,22 @@ function promote_operation(
     return Rational{promote_operation(*, S, T)}
 end
 
-function operate_to!(output::Rational, ::typeof(*), x::Rational, y::Rational)
-    xn, yd = Base.divgcd(promote(x.num, y.den)...)
-    xd, yn = Base.divgcd(promote(x.den, y.num)...)
-    operate_to!(output.num, *, xn, yn)
-    operate_to!(output.den, *, xd, yd)
+function buffer_for(::typeof(*), ::Type{Rational{S}}, ::Type{Rational{T}}) where {S,T}
+    U = promote_operation(gcd, S, T)
+    return zero(Rational{S}), zero(Rational{T}), zero(U)
+end
+
+function buffered_operate_to!(buffer, output::Rational, ::typeof(*), x::Rational, y::Rational)
+    # Cannot use `output.num` and `output.den` as buffer as `output` might be an alias for `x`
+    _buffered_divgcd(buffer[3], x.num, buffer[1].num, y.den, buffer[2].den)
+    _buffered_divgcd(buffer[3], x.den, buffer[1].den, y.num, buffer[2].num)
+    operate_to!(output.num, *, buffer[1].num, buffer[2].num)
+    operate_to!(output.den, *, buffer[1].den, buffer[2].den)
     return output
+end
+
+function operate_to!(output::Rational, ::typeof(*), x::Rational, y::Rational)
+    return buffered_operate_to!(buffer_for(*, typeof(x), typeof(y)), output, *, x, y)
 end
 
 # gcd
@@ -141,8 +159,9 @@ end
 # add_mul and sub_mul
 
 # Buffer to hold the product
-function buffer_for(::AddSubMul, args::Vararg{Type{<:Rational},N}) where {N}
-    return zero(promote_operation(*, args...))
+function buffer_for(op::AddSubMul, args::Vararg{Type{<:Rational},N}) where {N}
+    U = promote_operation(*, args...)
+    return buffer_for(*, Base.tail(args)...), zero(U), buffer_for(add_sub_op(op), args[1], U)
 end
 
 function operate_to!(
@@ -158,7 +177,7 @@ function operate_to!(
 end
 
 function buffered_operate_to!(
-    buffer::Rational,
+    buffer,
     output::Rational,
     op::AddSubMul,
     a::Rational,
@@ -166,12 +185,12 @@ function buffered_operate_to!(
     y::Rational,
     args::Vararg{Rational,N},
 ) where {N}
-    operate_to!(buffer, *, x, y, args...)
-    return operate_to!(output, add_sub_op(op), a, buffer)
+    buffered_operate_to!(buffer[1], buffer[2], *, x, y, args...)
+    return buffered_operate_to!(buffer[3], output, add_sub_op(op), a, buffer[2])
 end
 
 function buffered_operate!(
-    buffer::Rational,
+    buffer,
     op::AddSubMul,
     x::Rational,
     args::Vararg{Any,N},

--- a/test/big.jl
+++ b/test/big.jl
@@ -23,11 +23,15 @@ function allocation_test(
     g = op(a, b)
     @test c === short_to(c, a, b)
     @test g == c
-    @test a === short(a, b)
-    @test g == a
-    alloc_test_le(() -> short(a, b), n)
+    A = MA.copy_if_mutable(a)
+    @test A === short(A, b)
+    @test g == A
+    alloc_test_le(() -> short(A, b), n)
     alloc_test_le(() -> short_to(c, a, b), n)
+    @test g == buffered_operate!(nothing, op, MA.copy_if_mutable(a), b)
+    @test g == buffered_operate_to!(nothing, c, op, a, b)
     buffer = buffer_for(op, typeof(a), typeof(b))
+    @test g == buffered_operate_to!(buffer, c, op, a, b)
     alloc_test(() -> buffered_operate_to!(buffer, c, op, a, b), 0)
     return
 end
@@ -39,6 +43,8 @@ function add_sub_mul_test(
     b = T(3),
     c = T(4),
 )
+    g = op(a, b, c)
+    @test g == buffered_operate!(nothing, op, MA.copy_if_mutable(a), b, c)
     buffer = buffer_for(op, typeof(a), typeof(b), typeof(c))
     alloc_test(() -> buffered_operate!(buffer, op, a, b, c), 0)
 end

--- a/test/big.jl
+++ b/test/big.jl
@@ -28,25 +28,19 @@ function allocation_test(
     @test g == A
     alloc_test_le(() -> short(A, b), n)
     alloc_test_le(() -> short_to(c, a, b), n)
-    @test g == buffered_operate!(nothing, op, MA.copy_if_mutable(a), b)
-    @test g == buffered_operate_to!(nothing, c, op, a, b)
-    buffer = buffer_for(op, typeof(a), typeof(b))
-    @test g == buffered_operate_to!(buffer, c, op, a, b)
-    alloc_test(() -> buffered_operate_to!(buffer, c, op, a, b), 0)
+    @test g == MA.buffered_operate!(nothing, op, MA.copy_if_mutable(a), b)
+    @test g == MA.buffered_operate_to!(nothing, c, op, a, b)
+    buffer = MA.buffer_for(op, typeof(a), typeof(b))
+    @test g == MA.buffered_operate_to!(buffer, c, op, a, b)
+    alloc_test(() -> MA.buffered_operate_to!(buffer, c, op, a, b), 0)
     return
 end
 
-function add_sub_mul_test(
-    op,
-    T;
-    a = T(2),
-    b = T(3),
-    c = T(4),
-)
+function add_sub_mul_test(op, T; a = T(2), b = T(3), c = T(4))
     g = op(a, b, c)
-    @test g == buffered_operate!(nothing, op, MA.copy_if_mutable(a), b, c)
-    buffer = buffer_for(op, typeof(a), typeof(b), typeof(c))
-    alloc_test(() -> buffered_operate!(buffer, op, a, b, c), 0)
+    @test g == MA.buffered_operate!(nothing, op, MA.copy_if_mutable(a), b, c)
+    buffer = MA.buffer_for(op, typeof(a), typeof(b), typeof(c))
+    return alloc_test(() -> MA.buffered_operate!(buffer, op, a, b, c), 0)
 end
 @testset "$T" for T in [BigInt, BigFloat, Rational{BigInt}]
     MA.Test.int_test(T)

--- a/test/big.jl
+++ b/test/big.jl
@@ -48,8 +48,8 @@ end
         allocation_test(+, T, MA.add!!, MA.add_to!!, T <: Rational ? 168 : 0)
         allocation_test(-, T, MA.sub!!, MA.sub_to!!, T <: Rational ? 168 : 0)
         allocation_test(*, T, MA.mul!!, MA.mul_to!!, T <: Rational ? 240 : 0)
-        add_sub_mul_test(add_mul, T)
-        add_sub_mul_test(sub_mul, T)
+        add_sub_mul_test(MA.add_mul, T)
+        add_sub_mul_test(MA.sub_mul, T)
         if T <: Rational # https://github.com/jump-dev/MutableArithmetics.jl/issues/167
             allocation_test(
                 +,


### PR DESCRIPTION

```julia
using MutableArithmetics
using BenchmarkTools

function non_mutable()
    T = Rational{BigInt}
    a = one(T)
    b = one(T)
    c = one(T)
    @benchmark $a + $b * $c
end

function mutable()
    T = Rational{BigInt}
    a = one(T)
    b = one(T)
    c = one(T)
    buffer = buffer_for(add_mul, T, T, T)
    @benchmark buffered_operate!($buffer, add_mul, $a, $b, $c)
end

julia> non_mutable()
BenchmarkTools.Trial: 10000 samples with 550 evaluations.
 Range (min … max):  208.478 ns … 24.738 μs  ┊ GC (min … max):  0.00% … 59.11%
 Time  (median):     234.192 ns              ┊ GC (median):     0.00%
 Time  (mean ± σ):   399.755 ns ±  1.942 μs  ┊ GC (mean ± σ):  23.80% ±  4.82%

  ▄▅▄▅███▆▅▄▃▃▂▁▂▁▁▁                                           ▂
  ████████████████████▇▇▇▇▇▆▇███▇▆▅▅▅▅▄▅▅▆▅▆▆▅▃▃▄▃▃▃▃▅▃▃▁▃▅▄▅▃ █
  208 ns        Histogram: log(frequency) by time       474 ns <

 Memory estimate: 576 bytes, allocs estimate: 18.

# BEFORE THIS PR

julia> mutable()
BenchmarkTools.Trial: 10000 samples with 237 evaluations.
 Range (min … max):  315.295 ns … 257.897 μs  ┊ GC (min … max):  0.00% … 55.17%
 Time  (median):     348.675 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):   711.304 ns ±   9.011 μs  ┊ GC (mean ± σ):  26.71% ±  2.12%

           ▆█▃                                                   
  ▂▂▂▃▃▃▄▆▇████▅▄▄▃▃▃▃▃▂▂▂▂▂▂▂▂▃▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂ ▃
  315 ns           Histogram: frequency by time          500 ns <

 Memory estimate: 408 bytes, allocs estimate: 21.


# AFTER THIS PR

julia> mutable()
BenchmarkTools.Trial: 10000 samples with 927 evaluations.
 Range (min … max):  101.798 ns … 147.569 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     109.350 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   110.340 ns ±   4.182 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

             ▁▄▄▃▁▄▆█▅▄▁                                         
  ▂▂▂▃▂▂▁▃▂▄▇████████████▇▇▆▆▇▅▄▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▂▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂ ▄
  102 ns           Histogram: frequency by time          126 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Closes https://github.com/jump-dev/MutableArithmetics.jl/issues/187