### PR TITLE
SparseArrays: fix for nightly Julia, ilog2 -> top_set_bit

### DIFF
--- a/src/implementations/SparseArrays.jl
+++ b/src/implementations/SparseArrays.jl
@@ -264,7 +264,7 @@ end
 
 # Taken from the internal function `Base.top_set_bit`, added in
 # https://github.com/JuliaLang/julia/pull/47523
-_top_set_bit(x::Integer) = 8sizeof(x) - leading_zeros(x)
+_top_set_bit(x::Integer) = 8 * sizeof(x) - leading_zeros(x)
 
 # Taken from `SparseArrays.prefer_sort` added in Julia v1.1.
 function _prefer_sort(nz::Integer, m::Integer)

--- a/src/implementations/SparseArrays.jl
+++ b/src/implementations/SparseArrays.jl
@@ -262,9 +262,13 @@ function operate!(
     return ret
 end
 
+# Taken from the internal function `Base.top_set_bit`, added in
+# https://github.com/JuliaLang/julia/pull/47523
+_top_set_bit(x::Integer) = 8sizeof(x) - leading_zeros(x)
+
 # Taken from `SparseArrays.prefer_sort` added in Julia v1.1.
 function _prefer_sort(nz::Integer, m::Integer)
-    return m > 6 && 3 * SparseArrays.ilog2(nz) * nz < m
+    return m > 6 && 3 * _top_set_bit(nz) * nz < m
 end
 
 function operate!(


### PR DESCRIPTION
Issue: MutableArithmetics for SparseArrays is broken on nightly Julia because SparseArrays.ilog2 doesn't exist anymore.

This adds the function _top_set_bit and uses it instead of ilog2.

See
https://github.com/JuliaSparse/SparseArrays.jl/pull/324 and
https://github.com/JuliaLang/julia/pull/47523