### PR TITLE
Support x[;kwargs...] syntax in rewrite macro

### DIFF
--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -340,17 +340,6 @@ function _is_comparison(ex::Expr)
     return false
 end
 
-# `x[i = 1]` is a somewhat common user error. Catch it here.
-function _has_assignment_in_ref(ex::Expr)
-    if isexpr(ex, :ref)
-        return any(x -> isexpr(x, :kw), ex.args)
-    else
-        return any(_has_assignment_in_ref, ex.args)
-    end
-end
-
-_has_assignment_in_ref(other) = false
-
 function _rewrite_sum(
     vectorized::Bool,
     minus::Bool,
@@ -702,8 +691,6 @@ function _rewrite(
         )
     elseif isa(inner_factor, Expr) && _is_comparison(inner_factor)
         error("Unexpected comparison in expression `$inner_factor`.")
-    elseif isa(inner_factor, Expr) && _has_assignment_in_ref(inner_factor)
-        error("Unexpected assignment in expression `$inner_factor`.")
     end
     # None of the special cases were hit! This probably means we are vectorized.
     code = _write_add_mul(

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -42,11 +42,6 @@ function is_supported_test(T)
 end
 
 function error_test(x, y, z)
-    # $(:(y[j=1])) does not print the same on Julia v1.3 or Julia 1.4
-    err = ErrorException("Unexpected assignment in expression `$(:(y[j=1]))`.")
-    @test_macro_throws err MA.@rewrite y[j = 1]
-    err = ErrorException("Unexpected assignment in expression `$(:(x[i=1]))`.")
-    @test_macro_throws err MA.@rewrite y + x[i = 1] + z
     err = ErrorException(
         "The curly syntax (sum{},prod{},norm2{}) is no longer supported. Expression: `sum{(i for i = 1:2)}`.",
     )
@@ -162,4 +157,15 @@ end
         @test MA.@rewrite(X - Y) == X - Y
         @test MA.@rewrite(Y - X) == Y - X
     end
+end
+
+struct _KwargRef{K,V}
+    data::Dict{K,V}
+end
+
+Base.getindex(x::_KwargRef; i) = x.data[i]
+
+@testset "test_rewrite_kw_in_ref" begin
+    x = _KwargRef(Dict(i => i + 1 for i in 2:4))
+    @test MA.@rewrite(sum(x[i=j] for j in 2:4)) == 12
 end

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -167,5 +167,5 @@ Base.getindex(x::_KwargRef; i) = x.data[i]
 
 @testset "test_rewrite_kw_in_ref" begin
     x = _KwargRef(Dict(i => i + 1 for i in 2:4))
-    @test MA.@rewrite(sum(x[i=j] for j in 2:4)) == 12
+    @test MA.@rewrite(sum(x[i = j] for j in 2:4)) == 12
 end

--- a/test/rewrite_generic.jl
+++ b/test/rewrite_generic.jl
@@ -284,6 +284,21 @@ function test_splatting()
     return
 end
 
+struct _KwargRef{K,V}
+    data::Dict{K,V}
+end
+
+Base.getindex(x::_KwargRef; i) = x.data[i]
+
+function test_rewrite_kw_in_ref()
+    x = _KwargRef(Dict(i => i + 1 for i in 2:4))
+    @test MA.@rewrite(
+        sum(x[i = j] for j in 2:4),
+        move_factors_into_sums = false,
+    ) == 12
+    return
+end
+
 end  # module
 
 TestRewriteGeneric.runtests()


### PR DESCRIPTION
This is preventing JuMP from working with `DimensionalData.jl`: https://github.com/jump-dev/JuMP.jl/issues/3214#issuecomment-1430265935, or indeed, any types which implement `getindex(x; kwargs...)`. (The trick is that `x[a=1]` lowers to `getindex(x; a = 1)`.)

I think this was originally added so that people writing `@variable(model, x[a=1:2])` would get an error if they typed `@constraint(model, x[a=1] <= 1)`, but it seems like breaking other code is worse than providing a better error message is people mis-use JuMP containers.

This will break the JuMP tests for the same reason that https://github.com/jump-dev/JuMP.jl/pull/3125/files#diff-1506a102465c4b93f811ff0af5bf5b358e8a13a46eefab5fe5d77c8aab4bb0f9R641 does.