### PR TITLE
Use import MutableArithmetics as MA and fix resulting hygiene issue

### DIFF
--- a/src/Test/Test.jl
+++ b/src/Test/Test.jl
@@ -6,8 +6,7 @@
 
 module Test
 
-import MutableArithmetics
-const MA = MutableArithmetics
+import MutableArithmetics as MA
 
 using LinearAlgebra, SparseArrays, Test
 

--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -372,11 +372,7 @@ end
 
 function _start_summing(::Nothing, first_term::Function)
     variable = gensym()
-    return Expr(
-        :block,
-        :($variable = MutableArithmetics.Zero()),
-        first_term(variable),
-    )
+    return Expr(:block, Expr(:(=), variable, Zero()), first_term(variable))
 end
 
 function _start_summing(current_sum::Symbol, first_term::Function)
@@ -392,19 +388,13 @@ function _write_add_mul(
     right_factors,
     new_var::Symbol,
 )
-    if vectorized
-        f = :(MutableArithmetics.broadcast!!)
-    else
-        f = :(MutableArithmetics.operate!!)
-    end
-    op = minus ? :(MutableArithmetics.sub_mul) : :(MutableArithmetics.add_mul)
     return _start_summing(
         current_sum,
         current_sum -> begin
             call_expr = Expr(
                 :call,
-                f,
-                op,
+                vectorized ? broadcast!! : operate!!,
+                minus ? sub_mul : add_mul,
                 current_sum,
                 left_factors...,
                 inner_factors...,

--- a/test/SparseArrays.jl
+++ b/test/SparseArrays.jl
@@ -9,11 +9,9 @@ module TestInterfaceSparseArrays
 using Test
 
 import LinearAlgebra
-import MutableArithmetics
+import MutableArithmetics as MA
 import Random
 import SparseArrays
-
-const MA = MutableArithmetics
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -5,8 +5,7 @@
 # one at http://mozilla.org/MPL/2.0/.
 
 using Test
-import MutableArithmetics
-const MA = MutableArithmetics
+import MutableArithmetics as MA
 
 @testset "Int" begin
     a = [1, 2]

--- a/test/dummy.jl
+++ b/test/dummy.jl
@@ -5,8 +5,7 @@
 # one at http://mozilla.org/MPL/2.0/.
 
 using LinearAlgebra
-import MutableArithmetics
-const MA = MutableArithmetics
+import MutableArithmetics as MA
 
 # It does not support operation with floats on purpose to test that
 # MutableArithmetics does not convert to float when it shouldn't.

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -9,10 +9,12 @@
 
 module M
 using Test
-import MutableArithmetics
+# Import it as a different name so that we test whether MutableArithmetics is
+# needed in the current scope.
+import MutableArithmetics as NewSymbolMA
 
 macro _rewrite(expr)
-    variable, code = MutableArithmetics.rewrite(expr)
+    variable, code = NewSymbolMA.rewrite(expr)
     return quote
         $code
         $variable
@@ -20,23 +22,23 @@ macro _rewrite(expr)
 end
 
 # Don't include this in `@test` to make sure it is in global scope
-x = MutableArithmetics.@rewrite sum(i for i in 1:10)
+x = NewSymbolMA.@rewrite sum(i for i in 1:10)
 @test x == 55
 x = @_rewrite sum(i for i in 1:10)
 @test x == 55
 
-x = MutableArithmetics.@rewrite sum(i for i in 1:10 if isodd(i))
+x = NewSymbolMA.@rewrite sum(i for i in 1:10 if isodd(i))
 @test x == 25
 x = @_rewrite sum(i for i in 1:10 if isodd(i))
 @test x == 25
 
-x = MutableArithmetics.@rewrite sum(i * j for i in 1:4 for j ∈ 1:4 if i == j)
+x = NewSymbolMA.@rewrite sum(i * j for i in 1:4 for j ∈ 1:4 if i == j)
 @test x == 30
 x = @_rewrite sum(i * j for i in 1:4 for j ∈ 1:4 if i == j)
 @test x == 30
 
 x = big(1)
-y = MutableArithmetics.@rewrite(x + (x + 1)^1)
+y = NewSymbolMA.@rewrite(x + (x + 1)^1)
 @test y == 3
 
 end

--- a/test/int.jl
+++ b/test/int.jl
@@ -5,8 +5,7 @@
 # one at http://mozilla.org/MPL/2.0/.
 
 using Test
-import MutableArithmetics
-const MA = MutableArithmetics
+import MutableArithmetics as MA
 
 @testset "promote_operation" begin
     @test MA.promote_operation(MA.zero, Int) == Int

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -5,8 +5,7 @@
 # one at http://mozilla.org/MPL/2.0/.
 
 using Test
-import MutableArithmetics
-const MA = MutableArithmetics
+import MutableArithmetics as MA
 
 struct DummyMutable end
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -5,8 +5,7 @@
 # one at http://mozilla.org/MPL/2.0/.
 
 using Test
-import MutableArithmetics
-const MA = MutableArithmetics
+import MutableArithmetics as MA
 
 include("utilities.jl")
 

--- a/test/range.jl
+++ b/test/range.jl
@@ -5,8 +5,7 @@
 # one at http://mozilla.org/MPL/2.0/.
 
 using Test
-import MutableArithmetics
-const MA = MutableArithmetics
+import MutableArithmetics as MA
 
 function mutating_step_range_test(::Type{T}) where {T}
     r = MA.MutatingStepRange(T(2), T(3), T(9))

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -5,8 +5,7 @@
 # one at http://mozilla.org/MPL/2.0/.
 
 using LinearAlgebra, SparseArrays, Test
-import MutableArithmetics
-const MA = MutableArithmetics
+import MutableArithmetics as MA
 
 @testset "Zero" begin
     z = MA.Zero()

--- a/test/rewrite_generic.jl
+++ b/test/rewrite_generic.jl
@@ -8,9 +8,7 @@ module TestRewriteGeneric
 
 using Test
 
-import MutableArithmetics
-
-const MA = MutableArithmetics
+import MutableArithmetics as MA
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,7 @@
 # one at http://mozilla.org/MPL/2.0/.
 
 using Test
-import MutableArithmetics
-const MA = MutableArithmetics
+import MutableArithmetics as MA
 
 include("utilities.jl")
 


### PR DESCRIPTION
x-ref https://github.com/jump-dev/JuMP.jl/pull/3222

Changing to `import MutableArithmetics as NewSymbolMA` in the test helped catch a couple of hygiene issues which expected the `MutableArithmetics` symbol to be in the namespace of any rewrites.