### PR TITLE
Fix add_dot with Complex numbers

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -664,15 +664,15 @@ function buffered_operate_fallback!!(
     return buffered_operate!(buffer, op, args...)
 end
 
-# For most types, `dot(b, c) = transpose(b) * c`.
-promote_operation_fallback(::typeof(transpose), a::Type) = a
+# For most types, `dot(b, c) = adjoint(b) * c`.
+promote_operation_fallback(::typeof(adjoint), a::Type) = a
 
 function promote_operation_fallback(
     ::typeof(LinearAlgebra.dot),
     ::Type{A},
     ::Type{B},
 ) where {A,B}
-    return promote_operation(*, promote_operation(transpose, A), B)
+    return promote_operation(*, A, B)
 end
 
 function promote_operation_fallback(
@@ -685,15 +685,15 @@ function promote_operation_fallback(
 end
 
 function buffer_for(::typeof(add_dot), a::Type, b::Type, c::Type)
-    return buffer_for(add_mul, a, promote_operation(transpose, b), c)
+    return buffer_for(add_mul, a, b, c)
 end
 
 function operate_to_fallback!(::IsMutable, output, ::typeof(add_dot), a, b, c)
-    return operate_to!(output, add_mul, a, transpose(b), c)
+    return operate_to!(output, add_mul, a, b, c)
 end
 
 function operate_fallback!(::IsMutable, ::typeof(add_dot), a, b, c)
-    return operate!(add_mul, a, transpose(b), c)
+    return operate!(add_mul, a, b, c)
 end
 
 function buffered_operate_to_fallback!(
@@ -705,7 +705,7 @@ function buffered_operate_to_fallback!(
     b,
     c,
 )
-    return buffered_operate_to!(buffer, output, add_mul, a, transpose(b), c)
+    return buffered_operate_to!(buffer, output, add_mul, a, b, c)
 end
 
 function buffered_operate_fallback!(
@@ -716,5 +716,5 @@ function buffered_operate_fallback!(
     b,
     c,
 )
-    return buffered_operate!(buffer, add_mul, a, transpose(b), c)
+    return buffered_operate!(buffer, add_mul, a, b, c)
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -664,15 +664,15 @@ function buffered_operate_fallback!!(
     return buffered_operate!(buffer, op, args...)
 end
 
-# For most types, `dot(b, c) = adjoint(b) * c`.
-promote_operation_fallback(::typeof(adjoint), a::Type) = a
+# For most types, `dot(b, c) = transpose(b) * c`.
+promote_operation_fallback(::typeof(transpose), a::Type) = a
 
 function promote_operation_fallback(
     ::typeof(LinearAlgebra.dot),
     ::Type{A},
     ::Type{B},
 ) where {A,B}
-    return promote_operation(*, promote_operation(adjoint, A), B)
+    return promote_operation(*, promote_operation(transpose, A), B)
 end
 
 function promote_operation_fallback(
@@ -685,15 +685,15 @@ function promote_operation_fallback(
 end
 
 function buffer_for(::typeof(add_dot), a::Type, b::Type, c::Type)
-    return buffer_for(add_mul, a, promote_operation(adjoint, b), c)
+    return buffer_for(add_mul, a, promote_operation(transpose, b), c)
 end
 
 function operate_to_fallback!(::IsMutable, output, ::typeof(add_dot), a, b, c)
-    return operate_to!(output, add_mul, a, adjoint(b), c)
+    return operate_to!(output, add_mul, a, transpose(b), c)
 end
 
 function operate_fallback!(::IsMutable, ::typeof(add_dot), a, b, c)
-    return operate!(add_mul, a, adjoint(b), c)
+    return operate!(add_mul, a, transpose(b), c)
 end
 
 function buffered_operate_to_fallback!(
@@ -705,7 +705,7 @@ function buffered_operate_to_fallback!(
     b,
     c,
 )
-    return buffered_operate_to!(buffer, output, add_mul, a, adjoint(b), c)
+    return buffered_operate_to!(buffer, output, add_mul, a, transpose(b), c)
 end
 
 function buffered_operate_fallback!(
@@ -716,5 +716,5 @@ function buffered_operate_fallback!(
     b,
     c,
 )
-    return buffered_operate!(buffer, add_mul, a, adjoint(b), c)
+    return buffered_operate!(buffer, add_mul, a, transpose(b), c)
 end


### PR DESCRIPTION
Closes https://github.com/jump-dev/JuMP.jl/issues/3242

@blegat, why was `adjoint` used here instead of `transpose`? 

LinearAlgebra uses `conj`, which isn't quite the same as `add_dot` of the `adjoint`.
```Julia
julia> A = [1 2+3im; 2-3im 4]
2×2 Matrix{Complex{Int64}}:
 1+0im  2+3im
 2-3im  4+0im

julia> LinearAlgebra.dot(A, A)
43 + 0im

julia> sum(conj(A) .* A)
43 + 0im

julia> sum(adjoint(A) .* A)
7 + 0im

julia> sum(transpose(A) .* A)
43 + 0im
```

I think you perhaps intended to use `dot` for the individual elements instead of `*`?
```julia
julia> sum(LinearAlgebra.dot.(conj(A), A))
7 + 0im

julia> sum(LinearAlgebra.dot.(adjoint(A), A))
43 + 0im

julia> sum(LinearAlgebra.dot.(transpose(A), A))
7 + 0im
```

So perhaps `adjoint` is correct and the fix is elsewhere.