### PR TITLE
add evalpoly

### DIFF
--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -111,6 +111,8 @@ include("implementations/MutatingStepRange.jl")
 include("implementations/Rational.jl")
 include("implementations/SparseArrays.jl")
 
+include("evalpoly.jl")
+
 include("reduce.jl")
 
 """

--- a/src/evalpoly.jl
+++ b/src/evalpoly.jl
@@ -1,0 +1,36 @@
+# Copyright (c) 2023 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
+# `Base.evalpoly` MA operation implemented using Horner's scheme. For
+# real-valued polynomials with real coefficients.
+
+function promote_operation(
+    ::typeof(Base.evalpoly),
+    ::Type{F},
+    ::Type{<:Union{Tuple,AbstractVector}},
+) where {F<:Real}
+    return F
+end
+
+function operate_to!(
+    val::F,
+    ::typeof(Base.evalpoly),
+    x::F,
+    coefs::Union{Tuple,AbstractVector},
+) where {F<:Real}
+    operate!(zero, val)
+
+    # An empty collection of coefficients is interpreted as the zero polynomial.
+    isempty(coefs) && return val
+
+    operate!(+, val, last(coefs))
+
+    for i in eachindex(coefs)[(end-1):-1:begin]
+        operate!(Base.muladd, val, x, coefs[i])
+    end
+
+    return val
+end

--- a/src/implementations/BigFloat.jl
+++ b/src/implementations/BigFloat.jl
@@ -437,3 +437,21 @@ function buffered_operate_to!(
 
     return sum
 end
+
+# Base.evalpoly
+
+function operate!(
+    op::typeof(Base.evalpoly),
+    out::F,
+    coefs::Union{Tuple,AbstractVector},
+) where {F<:BigFloat}
+    return operate_to!(out, op, mutable_copy(out), coefs)
+end
+
+function operate(
+    op::typeof(Base.evalpoly),
+    x::F,
+    coefs::Union{Tuple,AbstractVector},
+) where {F<:BigFloat}
+    return operate_to!(zero(x), op, x, coefs)
+end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -206,7 +206,13 @@ function operate(
     return op(x, y, args...)
 end
 
-operate(op::Union{typeof(-),typeof(/),typeof(div)}, x, y) = op(x, y)
+function operate(
+    op::Union{typeof(-),typeof(/),typeof(div),typeof(evalpoly)},
+    x,
+    y,
+)
+    return op(x, y)
+end
 
 operate(::typeof(convert), ::Type{T}, x) where {T} = convert(T, x)
 

--- a/test/evalpoly.jl
+++ b/test/evalpoly.jl
@@ -1,0 +1,161 @@
+# Copyright (c) 2023 MutableArithmetics.jl contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
+abstract type OpSignature end
+struct RegularSignature <: OpSignature end
+struct ToSignature <: OpSignature end
+
+function signature_type_of(
+    ::Union{typeof(MA.operate),typeof(MA.operate!),typeof(MA.operate!!)},
+)
+    return RegularSignature()
+end
+
+function signature_type_of(
+    ::Union{typeof(MA.operate_to!),typeof(MA.operate_to!!)},
+)
+    return ToSignature()
+end
+
+function op_may_modify_first_argument(op::Function)
+    return (op != MA.operate) & (signature_type_of(op) == RegularSignature())
+end
+
+function op_is_allowed_for_arithmetic(
+    ::typeof(evalpoly),
+    ::Union{typeof(MA.operate!),typeof(MA.operate_to!)},
+    ::Type{F},
+) where {F<:Any}
+    return MA.mutability(F) == MA.IsMutable()
+end
+
+function op_is_allowed_for_arithmetic(
+    ::typeof(evalpoly),
+    ::Union{typeof(MA.operate),typeof(MA.operate!!),typeof(MA.operate_to!!)},
+    ::Type{F},
+) where {F<:Any}
+    return true
+end
+
+function allowed_allocated_byte_count(
+    ::typeof(evalpoly),
+    ::Union{typeof(MA.operate),typeof(MA.operate!),typeof(MA.operate!!)},
+    ::Type{F},
+) where {F<:Any}
+    return @allocated zero(F)
+end
+
+function allowed_allocated_byte_count(
+    ::typeof(evalpoly),
+    ::Union{typeof(MA.operate_to!),typeof(MA.operate_to!!)},
+    ::Type{F},
+) where {F<:Any}
+    return @allocated nothing
+end
+
+const evalpoly_supported_arithmetics =
+    (BigFloat, Rational{Int}, Float64, Float32, Int)
+
+const evalpoly_operations =
+    (MA.operate, MA.operate!, MA.operate_to!, MA.operate!!, MA.operate_to!!)
+
+@testset "evalpoly with $op and $F" for F in evalpoly_supported_arithmetics,
+    op in evalpoly_operations
+
+    op_is_allowed_for_arithmetic(evalpoly, op, F) || continue
+
+    sig = signature_type_of(op)
+
+    if MA.mutability(F) == MA.IsMutable()
+        @testset "empty coefficients $collection_type" for collection_type in
+                                                           ("vector", "tuple")
+            out = one(F)
+            x = one(F)
+            backup = MA.copy_if_mutable(x)
+            coefs = F[]
+            if collection_type == "tuple"
+                coefs = ()
+            end
+
+            # Check that the result value is OK
+            if sig == RegularSignature()
+                @test iszero(@inferred op(evalpoly, x, coefs))
+            elseif sig == ToSignature()
+                @test iszero(@inferred op(out, evalpoly, x, coefs))
+            else
+                error("unexpected")
+            end
+
+            # Check that the arguments are unmodified
+            op_may_modify_first_argument(op) || @test backup == x
+        end
+    end
+
+    @testset "exact values: $degree, $x_int" for degree in 0:4, x_int in -5:5
+        coefs_int = rand(-6:6, degree + 1)
+
+        coefs = map(F, coefs_int)
+        x = F(x_int)
+
+        reference = evalpoly(x, coefs)
+
+        @test reference == evalpoly(x_int, coefs_int)
+
+        @testset "collection type $collection_type" for collection_type in
+                                                        ("vector", "tuple")
+            out = zero(F)
+            if collection_type == "vector"
+                coefs_arg = coefs
+            else
+                coefs_arg = (coefs...,)
+            end
+            if sig == RegularSignature()
+                out = @inferred op(evalpoly, x, coefs_arg)
+            elseif sig == ToSignature()
+                out = @inferred op(out, evalpoly, x, coefs_arg)
+            else
+                error("unexpected")
+            end
+
+            # Check that the result value is OK
+            @test reference == out
+
+            # Check that the arguments are unmodified
+            if op_may_modify_first_argument(op)
+                x = F(x_int)
+            else
+                @test x == F(x_int)
+            end
+            @test coefs == map(F, coefs_int)
+        end
+    end
+
+    @testset "allocation" begin
+        byte_cnt = allowed_allocated_byte_count(evalpoly, op, F)
+        coefs_tuple = map(F, (0, 1, 0, 1, 1))
+        @testset "collection type $collection_type" for collection_type in
+                                                        ("vector", "tuple")
+            if collection_type == "vector"
+                coefs = collect(coefs_tuple)
+            else
+                coefs = coefs_tuple
+            end
+            local tested_fun
+            if sig == RegularSignature()
+                tested_fun = let x = one(F), coefs = coefs
+                    () -> op(evalpoly, x, coefs)
+                end
+            elseif sig == ToSignature()
+                tested_fun = let o = one(F), x = one(F), coefs = coefs
+                    () -> op(o, evalpoly, x, coefs)
+                end
+            else
+                error("unexpected")
+            end
+            alloc_test(tested_fun, byte_cnt)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,9 @@ end
 @testset "BigFloat dot" begin
     include("bigfloat_dot.jl")
 end
+@testset "evalpoly" begin
+    include("evalpoly.jl")
+end
 @testset "Broadcast" begin
     include("broadcast.jl")
 end


### PR DESCRIPTION
```
julia> setprecision(512)
512

julia> @benchmark evalpoly(x, coefs) setup=(x = rand(BigFloat); coefs = rand(BigFloat, 10);)
BenchmarkTools.Trial: 10000 samples with 10 evaluations.
 Range (min … max):  1.247 μs … 276.376 μs  ┊ GC (min … max): 0.00% … 96.44%
 Time  (median):     1.487 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.611 μs ±   3.876 μs  ┊ GC (mean ± σ):  3.30% ±  1.37%

         ▁▃▄▇█▇▃
  ▂▂▂▃▄▆████████▇▅▄▃▄▄▄▅▅▅▅▅▅▄▅▄▄▃▃▃▃▃▂▂▂▂▂▂▂▂▂▁▁▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  1.25 μs         Histogram: frequency by time        2.41 μs <

 Memory estimate: 1.20 KiB, allocs estimate: 18.

julia> @benchmark MA.operate(evalpoly, x, coefs) setup=(x = rand(BigFloat); coefs = rand(BigFloat, 10);)
BenchmarkTools.Trial: 10000 samples with 10 evaluations.
 Range (min … max):  1.119 μs …   3.092 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.335 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.343 μs ± 101.303 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                   ▁ ▂▃▃▃▆▆▆█▆▄
  ▂▁▂▂▂▂▂▃▃▄▅▅▆▇▇███▇███████████▆▅▄▄▄▅▄▅▅▅▅▄▄▄▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂ ▄
  1.12 μs         Histogram: frequency by time        1.64 μs <

 Memory estimate: 136 bytes, allocs estimate: 2.

julia> @benchmark MA.operate_to!!(o, evalpoly, x, coefs) setup=(o = BigFloat(); x = rand(BigFloat); coefs = rand(BigFloat, 10);)
BenchmarkTools.Trial: 10000 samples with 10 evaluations.
 Range (min … max):  1.070 μs …  2.645 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.241 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.236 μs ± 61.560 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                           ▁ ▁  ▂ ▂ ▄▁▄▂▄▃▆▃▆▄█▄▇▃▄
  ▂▁▂▂▂▂▂▃▂▃▃▃▃▄▄▅▅▅▅▇▆▇▇█▇██████████████████████████▅▅▄▃▃▃▂ ▅
  1.07 μs        Histogram: frequency by time        1.33 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Fixes #210 