### PR TITLE
use `StridedMaybeAdjOrTransMat` instead of defining it

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MutableArithmetics"
 uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 authors = ["Gilles Peiffer", "Benoît Legat", "Sascha Timme"]
-version = "1.2.3"
+version = "1.2.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -538,16 +538,11 @@ function Base.:*(
     return mul(A, B)
 end
 
-const StridedMaybeAdjOrTransMat{T} = Union{
-    StridedMatrix{T},
-    LinearAlgebra.Adjoint{T,<:StridedMatrix},
-    LinearAlgebra.Transpose{T,<:StridedMatrix},
-}
-
 # See https://github.com/JuliaLang/julia/pull/37898
 # The default fallback only used `promote_type` so it may get its wrong, e.g.,
 # for JuMP and MultivariatePolynomials.
 if VERSION >= v"1.7.0-DEV.1284"
+    using LinearAlgebra: StridedMaybeAdjOrTransMat
     _mat_mat_scalar(A, B, γ) = operate!!(*, operate(*, A, B), γ)
     function LinearAlgebra.mat_mat_scalar(
         A::StridedMaybeAdjOrTransMat{<:AbstractMutable},


### PR DESCRIPTION
This move avoids conflicts that may occur with slightly changing the use of the type parameter in https://github.com/JuliaLang/julia/pull/49521. It is necessary because in that linalg file, the `Blas*` restriction is usually used in the place of the eltype of the `StridedArray`, and not as the eltype of the `Adjoint` or `Transpose`. Moving the definition here into the VERSION branch neatly adopts that change and makes the package run smoothly across v1.6 - v1.10.