### PR TITLE
[WIP] operate! with add_dot

### DIFF
--- a/src/implementations/BigInt.jl
+++ b/src/implementations/BigInt.jl
@@ -132,7 +132,7 @@ function operate_to!(
     return operate!(op, output, c...)
 end
 
-function operate!(op::Function, x::BigInt, args::Vararg{Any,N}) where {N}
+function operate_fallback!(op::Function, x::BigInt, args::Vararg{Any,N}) where {N}
     return operate_to!(x, op, x, args...)
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -755,7 +755,7 @@ function promote_operation_fallback(
     ::Type{<:AbstractArray{A}},
     ::Type{<:AbstractArray{B}},
 ) where {A,B}
-    C = promote_operation(*, A, B)
+    C = promote_operation(LinearAlgebra.dot, A, B)
     return promote_operation(+, C, C)
 end
 

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -39,16 +39,21 @@ end
 
 _concrete_eltype(x) = isempty(x) ? eltype(x) : typeof(first(x))
 
+
+function operate!(op::typeof(add_dot), output, args::Vararg{Any,N}) where {N}
+    T = promote_map_reduce(op, _concrete_eltype.(args)...)
+    buffer = buffer_for(op, T, eltype.(args)...)
+    for I in zip(eachindex.(args)...)
+        output = buffered_operate!!(buffer, op, output, getindex.(args, I)...)
+    end
+    return output
+end
+
 function fused_map_reduce(op::F, args::Vararg{Any,N}) where {F<:Function,N}
     _check_same_length(args...)
     T = promote_map_reduce(op, _concrete_eltype.(args)...)
     accumulator = neutral_element(reduce_op(op), T)
-    buffer = buffer_for(op, T, eltype.(args)...)
-    for I in zip(eachindex.(args)...)
-        accumulator =
-            buffered_operate!!(buffer, op, accumulator, getindex.(args, I)...)
-    end
-    return accumulator
+    return operate!(op, accumulator, args...)
 end
 
 function operate(


### PR DESCRIPTION
Trying to make this work `operate!(add_dot, BigInt(), [A, A], [A, A])` where `A = ones(BigInt, 2, 2)` to remove the need for such hacks:
https://github.com/kalmarek/PropertyT.jl/blob/master/src/sos_sdps.jl#L144-L173

cc @kalmarek