### PR TITLE
add dispatch for dot between Symmetric and Hermitian

### DIFF
--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -51,25 +51,15 @@ function LinearAlgebra._dot_nonrecursive(
     return fused_map_reduce(add_mul, lhs, rhs)
 end
 
-function LinearAlgebra.dot(
-    lhs::AbstractArray{<:AbstractMutable},
-    rhs::AbstractArray,
-)
-    return operate(LinearAlgebra.dot, lhs, rhs)
-end
-
-function LinearAlgebra.dot(
-    lhs::AbstractArray,
-    rhs::AbstractArray{<:AbstractMutable},
-)
-    return operate(LinearAlgebra.dot, lhs, rhs)
-end
-
-function LinearAlgebra.dot(
-    lhs::AbstractArray{<:AbstractMutable},
-    rhs::AbstractArray{<:AbstractMutable},
-)
-    return operate(LinearAlgebra.dot, lhs, rhs)
+for types in (Symmetric, Hermitian, AbstractArray)
+    type_pairs = (types, types{<:AbstractMutable})
+    for T in type_pairs, S in type_pairs
+        if T <: types{<:AbstractMutable} || S <: types{<:AbstractMutable}
+            function LinearAlgebra.dot(lhs::T, rhs::S)
+                return operate(LinearAlgebra.dot, lhs, rhs)
+            end
+        end
+    end
 end
 
 # Special-case because the the base version wants to do

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -51,7 +51,7 @@ function LinearAlgebra._dot_nonrecursive(
     return fused_map_reduce(add_mul, lhs, rhs)
 end
 
-for types in (Symmetric, Hermitian, AbstractArray)
+for types in (LinearAlgebra.Symmetric, LinearAlgebra.Hermitian, AbstractArray)
     type_pairs = (types, types{<:AbstractMutable})
     for T in type_pairs, S in type_pairs
         if T <: types{<:AbstractMutable} || S <: types{<:AbstractMutable}


### PR DESCRIPTION
Fixes #234 

I've only added inner products when both arguments are Symmetric or Hermitian, for a total of 6 additional methods. I think if some user wants to take an inner product between a Symmetric or Hermitian and a general matrix they're just asking for trouble, and it's ok to leave them on their own.