### PR TITLE
Fix implementation of mul! for AbstractMatrix and AbstractVector

### DIFF
--- a/src/implementations/LinearAlgebra.jl
+++ b/src/implementations/LinearAlgebra.jl
@@ -223,41 +223,6 @@ function promote_array_mul(
     return Vector{promote_sum_mul(S, T)}
 end
 
-################################################################################
-# We roll our own matmul here (instead of using Julia's generic fallbacks)
-# because doing so allows us to accumulate the expressions for the inner loops
-# in-place.
-# Additionally, Julia's generic fallbacks can be finnicky when your array
-# elements aren't `<:Number`.
-
-# This method of `mul!` is adapted from upstream Julia. Note that we
-# confuse transpose with adjoint.
-#=
-> Copyright (c) 2009-2018: Jeff Bezanson, Stefan Karpinski, Viral B. Shah,
-> and other contributors:
->
-> https://github.com/JuliaLang/julia/contributors
->
-> Permission is hereby granted, free of charge, to any person obtaining
-> a copy of this software and associated documentation files (the
-> "Software"), to deal in the Software without restriction, including
-> without limitation the rights to use, copy, modify, merge, publish,
-> distribute, sublicense, and/or sell copies of the Software, and to
-> permit persons to whom the Software is furnished to do so, subject to
-> the following conditions:
->
-> The above copyright notice and this permission notice shall be
-> included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-=#
-
 function _dim_check(C::AbstractVector, A::AbstractMatrix, B::AbstractVector)
     mB = length(B)
     mA, nA = size(A)

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -303,9 +303,8 @@ end
 Base.size(x::Issue65Matrix) = size(x.x)
 Base.getindex(x::Issue65Matrix, args...) = getindex(x.x, args...)
 Base.axes(x::Issue65Matrix, n) = Issue65OneTo(size(x.x, n))
-Base.convert(::Type{Base.OneTo}, x::Issue65OneTo) = Base.OneTo(x.N)
-Base.iterate(x::Issue65OneTo) = (1, 1)
-Base.iterate(x::Issue65OneTo, i::Int) = ifelse(i >= x.N, nothing, (i+1, i+1))
+Base.iterate(x::Issue65OneTo) = iterate(Base.OneTo(x.N))
+Base.iterate(x::Issue65OneTo, arg) = iterate(Base.OneTo(x.N), arg)
 
 @testset "Issue #65" begin
     x = [1.0 2.0; 3.0 4.0]

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -303,6 +303,7 @@ end
 Base.size(x::Issue65Matrix) = size(x.x)
 Base.getindex(x::Issue65Matrix, args...) = getindex(x.x, args...)
 Base.axes(x::Issue65Matrix, n) = Issue65OneTo(size(x.x, n))
+Base.convert(::Type{Base.OneTo}, x::Issue65OneTo) = Base.OneTo(x.N)
 Base.iterate(x::Issue65OneTo) = iterate(Base.OneTo(x.N))
 Base.iterate(x::Issue65OneTo, arg) = iterate(Base.OneTo(x.N), arg)
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -304,6 +304,8 @@ Base.size(x::Issue65Matrix) = size(x.x)
 Base.getindex(x::Issue65Matrix, args...) = getindex(x.x, args...)
 Base.axes(x::Issue65Matrix, n) = Issue65OneTo(size(x.x, n))
 Base.convert(::Type{Base.OneTo}, x::Issue65OneTo) = Base.OneTo(x.N)
+Base.iterate(x::Issue65OneTo) = (1, 1)
+Base.iterate(x::Issue65OneTo, i::Int) = ifelse(i >= x.N, nothing, (i+1, i+1))
 
 @testset "Issue #65" begin
     x = [1.0 2.0; 3.0 4.0]


### PR DESCRIPTION
Closes #251

The previous implementations were incorrect because they did not account for non-`Base.OneTo` axes.