### PR TITLE
Fix promotion of outer product

### DIFF
--- a/src/implementations/LinearAlgebra.jl
+++ b/src/implementations/LinearAlgebra.jl
@@ -213,14 +213,14 @@ function promote_array_mul(
     ::Type{<:AbstractVector{S}},
     ::Type{<:LinearAlgebra.Adjoint{T,<:AbstractVector{T}}},
 ) where {S,T}
-    return Matrix{promote_sum_mul(S, T)}
+    return Matrix{promote_operation(*, S, T)}
 end
 
 function promote_array_mul(
     ::Type{<:AbstractVector{S}},
     ::Type{<:LinearAlgebra.Transpose{T,<:AbstractVector{T}}},
 ) where {S,T}
-    return Matrix{promote_sum_mul(S, T)}
+    return Matrix{promote_operation(*, S, T)}
 end
 
 function promote_array_mul(

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -404,8 +404,7 @@ end
     @test y == BigInt[10 14; 14 20]
 end
 
-struct Monomial
-end
+struct Monomial end
 LinearAlgebra.transpose(m::Monomial) = m
 LinearAlgebra.adjoint(m::Monomial) = m
 MA.promote_operation(::typeof(*), ::Type{Monomial}, ::Type{Monomial}) = Monomial

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -403,3 +403,23 @@ end
     y = MA.@rewrite sum(A[i, :] * LinearAlgebra.transpose(x[i, :]) for i in 1:2)
     @test y == BigInt[10 14; 14 20]
 end
+
+struct Monomial
+end
+LinearAlgebra.transpose(m::Monomial) = m
+LinearAlgebra.adjoint(m::Monomial) = m
+MA.promote_operation(::typeof(*), ::Type{Monomial}, ::Type{Monomial}) = Monomial
+Base.:*(m::Monomial, ::Monomial) = m
+
+# `Monomial` does not implement `+`, we should check that it does not prevent
+# to do outer products of vectors
+@testset "Vector*Transpose{Vector}_issue_256 with Monomial" begin
+    m = Monomial()
+    a = [m, m]
+    for f in [LinearAlgebra.transpose, LinearAlgebra.adjoint]
+        b = f(a)
+        T = MA.promote_operation(*, typeof(a), typeof(b))
+        @test T == typeof(a * b)
+        @test T == typeof(MA.operate(*, a, b))
+    end
+end


### PR DESCRIPTION
This is important when using `MultivariatePolynomials.Term` to infer that the `eltype` of the result is `Term` and not `Polynomial`.