### PR TITLE
Mutable addition and substraction of sparse arrays

### DIFF
--- a/src/implementations/LinearAlgebra.jl
+++ b/src/implementations/LinearAlgebra.jl
@@ -89,13 +89,13 @@ function _check_dims(A, B)
     return
 end
 
-function operate!(op::Union{typeof(+),typeof(-)}, A::Array, B::AbstractArray)
+function operate!(op::Union{typeof(+),typeof(-)}, A::AbstractArray, B::AbstractArray)
     _check_dims(A, B)
     return broadcast!(op, A, B)
 end
 
 function operate_to!(
-    output::Array,
+    output::AbstractArray,
     op::Union{typeof(+),typeof(-)},
     A::AbstractArray,
     B::AbstractArray,
@@ -116,7 +116,7 @@ end
 # We call `scaling_to_number` as `UniformScaling` do not support broadcasting
 function operate!(
     op::AddSubMul,
-    A::Array,
+    A::AbstractArray,
     B::AbstractArray,
     α::Vararg{Scaling,M},
 ) where {M}
@@ -126,7 +126,7 @@ end
 
 function operate!(
     op::AddSubMul,
-    A::Array,
+    A::AbstractArray,
     α::Scaling,
     B::AbstractArray,
     β::Vararg{Scaling,M},
@@ -137,7 +137,7 @@ end
 
 function operate!(
     op::AddSubMul,
-    A::Array,
+    A::AbstractArray,
     α1::Scaling,
     α2::Scaling,
     B::AbstractArray,

--- a/src/implementations/LinearAlgebra.jl
+++ b/src/implementations/LinearAlgebra.jl
@@ -89,7 +89,11 @@ function _check_dims(A, B)
     return
 end
 
-function operate!(op::Union{typeof(+),typeof(-)}, A::AbstractArray, B::AbstractArray)
+function operate!(
+    op::Union{typeof(+),typeof(-)},
+    A::AbstractArray,
+    B::AbstractArray,
+)
     _check_dims(A, B)
     return broadcast!(op, A, B)
 end
@@ -156,11 +160,17 @@ end
 
 # Fallback, we may be able to be more efficient in more cases by adding more
 # specialized methods.
-function operate!(op::AddSubMul, A::Array, x, y)
+function operate!(op::AddSubMul, A::AbstractArray, x, y)
     return operate!(op, A, x * y)
 end
 
-function operate!(op::AddSubMul, A::Array, x, y, args::Vararg{Any,N}) where {N}
+function operate!(
+    op::AddSubMul,
+    A::AbstractArray,
+    x,
+    y,
+    args::Vararg{Any,N},
+) where {N}
     @assert N > 0
     return operate!(op, A, x, *(y, args...))
 end

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -119,9 +119,22 @@ end
             "Cannot sum or substract a matrix of axes `$(axes(B))` into matrix of axes `$(axes(A))`, expected axes `$(axes(B))`.",
         )
         @test_throws err MA.operate!(+, A, B)
+        A = spzeros(2)
+        B = spzeros(2, 1)
+        err = DimensionMismatch(
+            "Cannot sum or substract a matrix of axes `$(axes(B))` into matrix of axes `$(axes(A))`, expected axes `$(axes(B))`.",
+        )
+        @test_throws err MA.operate!(+, A, B)
         output = zeros(2)
         A = zeros(2, 1)
         B = zeros(2, 1)
+        err = DimensionMismatch(
+            "Cannot sum or substract matrices of axes `$(axes(A))` and `$(axes(B))` into a matrix of axes `$(axes(output))`, expected axes `$(axes(B))`.",
+        )
+        @test_throws err MA.operate_to!(output, +, A, B)
+        output = spzeros(2)
+        A = spzeros(2, 1)
+        B = spzeros(2, 1)
         err = DimensionMismatch(
             "Cannot sum or substract matrices of axes `$(axes(A))` and `$(axes(B))` into a matrix of axes `$(axes(output))`, expected axes `$(axes(B))`.",
         )
@@ -451,6 +464,21 @@ function test_array_sum(::Type{T}) where {T}
     alloc_test(() -> MA.add!!(y, z), 0)
     alloc_test(() -> MA.operate_to!(x, +, y, z), 0)
     alloc_test(() -> MA.add_to!!(x, y, z), 0)
+    return
+end
+
+function test_sparse_vector_sum(::Type{T}) where {T}
+    x = sparsevec([1, 3], T[5, 7])
+    y = copy(x)
+    z = copy(y)
+    alloc_test(() -> MA.operate!(+, y, z), 0)
+    alloc_test(() -> MA.operate!(-, y, z), 0)
+    alloc_test(() -> MA.add!!(y, z), 0)
+    alloc_test(() -> MA.sub!!(y, z), 0)
+    alloc_test(() -> MA.operate_to!(x, +, y, z), 0)
+    alloc_test(() -> MA.operate_to!(x, -, y, z), 0)
+    alloc_test(() -> MA.add_to!!(x, y, z), 0)
+    alloc_test(() -> MA.sub_to!!(x, y, z), 0)
     return
 end
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -119,8 +119,8 @@ end
             "Cannot sum or substract a matrix of axes `$(axes(B))` into matrix of axes `$(axes(A))`, expected axes `$(axes(B))`.",
         )
         @test_throws err MA.operate!(+, A, B)
-        A = spzeros(2)
-        B = spzeros(2, 1)
+        A = SparseArrays.spzeros(2)
+        B = SparseArrays.spzeros(2, 1)
         err = DimensionMismatch(
             "Cannot sum or substract a matrix of axes `$(axes(B))` into matrix of axes `$(axes(A))`, expected axes `$(axes(B))`.",
         )
@@ -132,9 +132,9 @@ end
             "Cannot sum or substract matrices of axes `$(axes(A))` and `$(axes(B))` into a matrix of axes `$(axes(output))`, expected axes `$(axes(B))`.",
         )
         @test_throws err MA.operate_to!(output, +, A, B)
-        output = spzeros(2)
-        A = spzeros(2, 1)
-        B = spzeros(2, 1)
+        output = SparseArrays.spzeros(2)
+        A = SparseArrays.spzeros(2, 1)
+        B = SparseArrays.spzeros(2, 1)
         err = DimensionMismatch(
             "Cannot sum or substract matrices of axes `$(axes(A))` and `$(axes(B))` into a matrix of axes `$(axes(output))`, expected axes `$(axes(B))`.",
         )

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -9,7 +9,7 @@ import MutableArithmetics as MA
 
 struct CustomArray{T,N} <: AbstractArray{T,N} end
 
-import LinearAlgebra
+import LinearAlgebra, SparseArrays
 
 function dot_test(x, y)
     @test MA.operate(LinearAlgebra.dot, x, y) == LinearAlgebra.dot(x, y)
@@ -468,7 +468,7 @@ function test_array_sum(::Type{T}) where {T}
 end
 
 function test_sparse_vector_sum(::Type{T}) where {T}
-    x = sparsevec([1, 3], T[5, 7])
+    x = SparseArrays.sparsevec([1, 3], T[5, 7])
     y = copy(x)
     z = copy(y)
     alloc_test(() -> MA.operate!(+, y, z), 0)


### PR DESCRIPTION
Turns out `broadcast!` is well implemented for SparseArrays:
```julia
julia> v = sparsevec([1, 3], [π, 2π])
3-element SparseVector{Float64, Int64} with 2 stored entries:
  [1]  =  3.14159
  [3]  =  6.28319

julia> a = copy(v)
3-element SparseVector{Float64, Int64} with 2 stored entries:
  [1]  =  3.14159
  [3]  =  6.28319

julia> b = copy(v)
3-element SparseVector{Float64, Int64} with 2 stored entries:
  [1]  =  3.14159
  [3]  =  6.28319

julia> @btime Broadcast.broadcast!(+, $v, 3, $a, 2, $b)
  38.791 ns (0 allocations: 0 bytes)
3-element SparseVector{Float64, Int64} with 3 stored entries:
  [1]  =  11.2832
  [2]  =  5.0
  [3]  =  17.5664

julia> @btime Broadcast.broadcast!(-, $v, 3, $a)
  27.560 ns (0 allocations: 0 bytes)
3-element SparseVector{Float64, Int64} with 3 stored entries:
  [1]  =  -0.141593
  [2]  =  3.0
  [3]  =  -3.28319

julia> @btime Broadcast.broadcast!(-, $v, $a, $b)
  31.149 ns (0 allocations: 0 bytes)
3-element SparseVector{Float64, Int64} with 0 stored entries
```
Since what we need exactly matches the definition of `broadcast!`, we might as well call `broadcast!` by default for any `AbstractArray` which is what this PR does.