### PR TITLE
Fix size check of arrays when broadcasting

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -115,15 +115,12 @@ end
 # happen during broadcasting since we'll either need to return a different size
 # to `x`, or multiple copies of an argument will be used for different parts of
 # `x`. To simplify, let's just return `IsNotMutable` if the sizes are different,
-# which will be slower but correct. This is slightly complicated by the fact
-# that some AbstractArray do not support `size`, so we check with `length`
-# instead. If the `size`s are different, a later error will be thrown.
+# which will be slower but correct.
 function broadcast_mutability(
     x::AbstractArray,
     op,
     args::Vararg{Any,N},
 ) where {N}
-    @show x, args
     if !_checked_size(size(x), args)::Bool
         return IsNotMutable()
     end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -102,7 +102,7 @@ function broadcast_mutability(x, op, args::Vararg{Any,N}) where {N}
     return broadcast_mutability(typeof(x), op, typeof.(args)...)
 end
 
-_checked_size(s, x::AbstractArray) = length(x) == s
+_checked_size(s, x::AbstractArray) = size(x) == s
 _checked_size(::Any, ::Any) = true
 _checked_size(::Any, ::Tuple{}) = true
 function _checked_size(s, x::Tuple)
@@ -123,7 +123,8 @@ function broadcast_mutability(
     op,
     args::Vararg{Any,N},
 ) where {N}
-    if !_checked_size(length(x), args)::Bool
+    @show x, args
+    if !_checked_size(size(x), args)::Bool
         return IsNotMutable()
     end
     return broadcast_mutability(typeof(x), op, typeof.(args)...)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -115,13 +115,13 @@ function _try_size(x::AbstractArray)
 end
 _try_size(x::Array) = size(x)
 
-_checked_size(::Missing, ::Any) = false
 _checked_size(x_size::Any, y::AbstractArray) = x_size == _try_size(y)
 _checked_size(::Any, ::Any) = true
 _checked_size(::Any, ::Tuple{}) = true
 function _checked_size(x_size::Any, y::Tuple)
     return _checked_size(x_size, y[1]) && _checked_size(x_size, Base.tail(y))
 end
+_checked_size(::Missing, ::Tuple) = false
 
 # This method is a slightly tricky one:
 #

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -122,6 +122,7 @@ function _checked_size(x_size::Any, y::Tuple)
     return _checked_size(x_size, y[1]) && _checked_size(x_size, Base.tail(y))
 end
 _checked_size(::Missing, ::Tuple) = false
+_checked_size(::Missing, ::Tuple{}) = false
 
 # This method is a slightly tricky one:
 #

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -52,3 +52,10 @@ Base.BroadcastStyle(::Type{Struct221}) = BroadcastStyle221()
 @testset "promote_broadcast_for_new_style" begin
     @test MA.promote_broadcast(MA.add_mul, Vector{Int}, Struct221) === Any
 end
+
+@testset "broadcast_length_1_dimensions" begin
+    A = rand(2, 1, 3)
+    B = rand(2, 3)
+    @test MA.broadcast!!(MA.sub_mul, A, B) ≈ A .- B
+    @test MA.broadcast!!(MA.sub_mul, B, A) ≈ B .- A
+end


### PR DESCRIPTION
Closes #295

The previous check for `length` is incorrect because it ignores length 1 dimensions. But the comment explains some arrays do not support size. Which? `SparseAxisArray`? Do we really support broadcasting over that?