### PR TITLE
Fix fused_map_reduce when result is a matrix

### DIFF
--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -22,7 +22,7 @@ reduce_op(op::AddSubMul) = add_sub_op(op)
 
 reduce_op(::typeof(add_dot)) = +
 
-neutral_element(::typeof(+), T::Type) = zero(T)
+neutral_element(::typeof(+), T::Type) = Zero()
 
 map_op(::AddSubMul) = *
 


### PR DESCRIPTION
This changes the behavior because now the dot product of empty vectors is `MA.Zero()` :/

See also https://github.com/JuliaAlgebra/StarAlgebras.jl/issues/40

Closes https://github.com/jump-dev/MutableArithmetics.jl/issues/318