### PR TITLE
Fix mutable allocations in n-ary multiplication

### DIFF
--- a/src/rewrite_generic.jl
+++ b/src/rewrite_generic.jl
@@ -216,11 +216,8 @@ function _rewrite_generic(stack::Expr, expr::Expr)
         push!(stack.args, :($root = $rhs))
         for i in 4:length(expr.args)
             arg, _ = _rewrite_generic(stack, expr.args[i])
-            rhs = if is_mutable
-                Expr(:call, operate!!, *, root, arg)
-            else
-                Expr(:call, operate, *, root, arg)
-            end
+            # It is always safe to modify `root` here
+            rhs = Expr(:call, operate!!, *, root, arg)
             root = gensym()
             push!(stack.args, :($root = $rhs))
         end

--- a/test/rewrite_generic.jl
+++ b/test/rewrite_generic.jl
@@ -498,6 +498,18 @@ function test_allocations_rewrite_unary_minus()
     return
 end
 
+function test_allocations_rewrite_mult()
+    x = BigFloat[1, 2, 3]
+    y = MA.@rewrite(x[1] * x[2] * x[3], move_factors_into_sums = false)
+    @test y == BigFloat(6)
+    @test x == BigFloat[1, 2, 3]
+    total = @allocated (x[1] * x[2]) * x[3]
+    @test @allocated(
+        MA.@rewrite(x[1] * x[2] * x[3], move_factors_into_sums = false),
+    ) < total
+    return
+end
+
 end  # module
 
 TestRewriteGeneric.runtests()


### PR DESCRIPTION
I thought @joaquimg's suggestion (3) in https://github.com/NREL-Sienna/PowerSimulations.jl/pull/1218 was weird. It's because we weren't optimizing this case.

Before
```Julia
julia> model = Model();

julia> @variable(model, x)
x

julia> a, b = 2.0, 3.0
(2.0, 3.0)

julia> @allocated @expression(model, a * x * b)
1728
```

After

```julia
julia> model = Model();

julia> @variable(model, x)
x

julia> a, b = 2.0, 3.0
(2.0, 3.0)

julia> @allocated @expression(model, a * x * b)
1152
```

Before code:
```julia
julia> @macroexpand @expression(model, a * x * b)
quote
    #= REPL[66]:1 =#
    JuMP._valid_model(model, :model)
    begin
        #= /Users/oscar/.julia/packages/JuMP/CU7H5/src/macros.jl:399 =#
        let model = model
            #= /Users/oscar/.julia/packages/JuMP/CU7H5/src/macros.jl:400 =#
            begin
                #= /Users/oscar/.julia/packages/JuMP/CU7H5/src/macros/@expression.jl:86 =#
                begin
                    #= /Users/oscar/.julia/packages/JuMP/CU7H5/src/macros.jl:264 =#
                    var"#313###301" = begin
                            #= /Users/oscar/.julia/dev/MutableArithmetics/src/rewrite.jl:374 =#
                            let
                                #= /Users/oscar/.julia/dev/MutableArithmetics/src/rewrite.jl:375 =#
                                begin
                                    #= /Users/oscar/.julia/dev/MutableArithmetics/src/rewrite.jl:371 =#
                                    var"#314###302" = (MutableArithmetics.operate)(*, a, x)
                                    var"#315###303" = (MutableArithmetics.operate)(*, var"#314###302", b)
                                end
                                #= /Users/oscar/.julia/dev/MutableArithmetics/src/rewrite.jl:376 =#
                                var"#315###303"
                            end
                        end
                    #= /Users/oscar/.julia/packages/JuMP/CU7H5/src/macros.jl:265 =#
                    var"#316###304" = (JuMP.flatten!)((MutableArithmetics).copy_if_mutable(var"#313###301"))
                end
                #= /Users/oscar/.julia/packages/JuMP/CU7H5/src/macros/@expression.jl:89 =#
                JuMP._replace_zero(model, var"#316###304")
            end
        end
    end
end
```

Issue is this line, which allocates `y = a * x` and then `y * b`
```julia
                                    var"#314###302" = (MutableArithmetics.operate)(*, a, x)
                                    var"#315###303" = (MutableArithmetics.operate)(*, var"#314###302", b)
```