### PR TITLE
Checks for zeroness

### DIFF
--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -81,9 +81,6 @@ end
 
 Base.iszero(::Zero) = true
 Base.isone(::Zero) = false
-Base.:(==)(::Zero, x) = iszero(x)
-Base.:(==)(x, ::Zero) = iszero(x)
-Base.:(==)(::Zero, ::Zero) = true
 
 # These methods are used to provide an efficient implementation for the common
 # case like `x^2 * sum(f for i in 1:0)`, which lowers to

--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -79,6 +79,12 @@ function Base.:/(z::Zero, x::Any)
     end
 end
 
+Base.iszero(::Zero) = true
+Base.isone(::Zero) = false
+Base.:(==)(::Zero, x) = iszero(x)
+Base.:(==)(x, ::Zero) = iszero(x)
+Base.:(==)(::Zero, ::Zero) = true
+
 # These methods are used to provide an efficient implementation for the common
 # case like `x^2 * sum(f for i in 1:0)`, which lowers to
 # `_MA.operate!!(*, x^2, _MA.Zero())`. We don't need the method with reversed

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -19,6 +19,8 @@ import MutableArithmetics as MA
     @test -z isa MA.Zero
     @test +z isa MA.Zero
     @test *(z) isa MA.Zero
+    @test iszero(z)
+    @test !isone(z)
 end
 
 # Test that the macro call `m` throws an error exception during pre-compilation


### PR DESCRIPTION
Fix #331 
I also added equality definitions - if this is desired. However, it would be a breaking change - `iszero` and `isone` were simply not defined, so this is fine, but comparison with `Zero` went to the `===` fallback before and returned `false`. So I understand if you'd rather not have these comparisons.