### PR TITLE
Simplify promote_type_fallback

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -26,7 +26,7 @@ function promote_operation_fallback(
 end
 
 function promote_operation_fallback(
-    op::F,
+    ::F,
     args::Vararg{Type,N},
 ) where {F<:Function,N}
     return promote_type(args...)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -25,37 +25,11 @@ function promote_operation_fallback(
     )
 end
 
-_instantiate_zero(::Type{S}) where {S} = zero(S)
-_instantiate_oneunit(::Type{S}) where {S} = oneunit(S)
-
-# this is valid because Irrational numbers are defined in global scope as const
-_instantiate(::Type{S}) where {S<:Irrational} = S()
-_instantiate_zero(::Type{S}) where {S<:AbstractIrrational} = _instantiate(S)
-_instantiate_oneunit(::Type{S}) where {S<:AbstractIrrational} = _instantiate(S)
-
-# Julia v1.0.x has trouble with inference with the `Vararg` method, see
-# https://travis-ci.org/jump-dev/JuMP.jl/jobs/617606373
-function promote_operation_fallback(
-    op::Union{typeof(/),typeof(div)},
-    ::Type{S},
-    ::Type{T},
-) where {S,T}
-    return typeof(op(_instantiate_zero(S), _instantiate_oneunit(T)))
-end
-
-function promote_operation_fallback(
-    op::F,
-    ::Type{S},
-    ::Type{T},
-) where {F<:Function,S,T}
-    return typeof(op(_instantiate_zero(S), _instantiate_zero(T)))
-end
-
 function promote_operation_fallback(
     op::F,
     args::Vararg{Type,N},
 ) where {F<:Function,N}
-    return typeof(op(_instantiate_zero.(args)...))
+    return promote_type(args...)
 end
 
 promote_operation_fallback(::typeof(*), ::Type{T}) where {T} = T

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -31,7 +31,7 @@ end
     @test y == 5
     # FIXME This should not allocate but I couldn't figure out where these
     #       allocations come from.
-    n = (VERSION >= v"1.11" ? 42 : 30) * sizeof(Int)
+    n = (VERSION >= v"1.11" ? 14 : 10) * sizeof(Int)
     alloc_test(() -> MA.broadcast!!(+, a, b), n)
     alloc_test(() -> MA.broadcast!!(+, a, c), 0)
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -51,11 +51,6 @@ Base.@irrational theodorus 1.73205080756887729353 sqrt(big(3))
         i_theodorus() = MA.promote_operation(+, Int, typeof(theodorus))
         @test i_theodorus() == Float64
         alloc_test(i_theodorus, 0)
-        # test _instantiate(::Type{S}) where {S<:Irrational} return value
-        @test MA._instantiate(typeof(π)) == π
-        @test MA._instantiate(typeof(MathConstants.catalan)) ==
-              MathConstants.catalan
-        @test MA._instantiate(typeof(theodorus)) == theodorus
     end
 end
 


### PR DESCRIPTION
Suggested by @AayushSabharwal. I am wondering whether that wouldn't be better compared to what we have.
The types for which that does not work are the types from JuMP, MOI and MultivariatePolynomials for which we already have custom methods (because the fallback would be allocating).
This also won't work for `Matrix * Vector` but the fallback with `one` also don't work there.
It also fixes the following but that @AayushSabharwal just reported to me:
```julia
julia> MA.promote_operation(+, Number, Number)
Int64
```
It would also reduce the number of weird errors reported by users of JuMP saying `zero(::...)` is not defined.