### PR TITLE
Fix rewrite generic of sum(::Symbol; init)

### DIFF
--- a/test/rewrite_generic.jl
+++ b/test/rewrite_generic.jl
@@ -509,6 +509,15 @@ function test_allocations_rewrite_mult()
     return
 end
 
+function test_rewrite_init_symbol()
+    x = Int[]
+    y = MA.@rewrite(sum(x; init = 0), move_factors_into_sums = false)
+    @test y == 0
+    y = MA.@rewrite(sum(x, init = 0), move_factors_into_sums = false)
+    @test y == 0
+    return
+end
+
 end  # module
 
 TestRewriteGeneric.runtests()


### PR DESCRIPTION
x-ref https://discourse.julialang.org/t/jump-reports-an-error-when-attempting-to-sum-the-empty-denseaxisarray-as-the-objective-function/133332/3