### PR TITLE
Support many more MPFR functions

### DIFF
--- a/src/implementations/BigFloat.jl
+++ b/src/implementations/BigFloat.jl
@@ -287,7 +287,8 @@ end
 
 # trigonometric
 # Functions for which NaN results are converted to DomainError, following Base
-for f in (:sin, :cos, :tan, :cot, :sec, :csc, :acos, :asin, :atan, :acosh, :asinh, :atanh, :sinpi, :cospi, :tanpi)
+for f in (:sin, :cos, :tan, :cot, :sec, :csc, :acos, :asin, :atan, :acosh, :asinh, :atanh,
+          (VERSION ≥ v"1.10" ? (:sinpi, :cospi, :tanpi) : ())...)
     @eval @make_mpfr $f(x::BigFloat) -> $(Symbol(:mpfr_, f)) pre=begin
         isnan(x) && return operate_to!(out, copy, x)
     end post=begin
@@ -295,7 +296,7 @@ for f in (:sin, :cos, :tan, :cot, :sec, :csc, :acos, :asin, :atan, :acosh, :asin
     end
 end
 @make_mpfr sincos(::BigFloat)::Tuple{BigFloat,BigFloat} -> mpfr_sin_cos
-for f in (:sin, :cos, :tan)
+VERSION ≥ v"1.10" && for f in (:sin, :cos, :tan)
     @eval begin
         @make_mpfr $(Symbol(f, :d))(x::BigFloat) -> ($(Symbol(:mpfr_, f, :u)), 0x00000168) pre=begin
             isnan(x) && return operate_to!(out, copy, x)
@@ -311,7 +312,7 @@ for f in (:sin, :cos, :tan)
     end
 end
 @make_mpfr atan(::BigFloat, ::BigFloat) -> mpfr_atan2
-@make_mpfr atand(::BigFloat, ::BigFloat) -> (mpfr_atan2u, 0x00000168)
+VERSION ≥ v"1.10" && @make_mpfr atand(::BigFloat, ::BigFloat) -> (mpfr_atan2u, 0x00000168)
 
 # hyperbolic
 @make_mpfr cosh(::BigFloat) -> mpfr_cosh

--- a/src/implementations/BigFloat.jl
+++ b/src/implementations/BigFloat.jl
@@ -136,6 +136,9 @@ end
 @make_mpfr copy(::_MPFRMachineSigned) -> mpfr_set_si
 @make_mpfr copy(::_MPFRMachineUnsigned) -> mpfr_set_ui
 # the Julia MPFR library does not come with the set_sj/set_uj functions
+@make_mpfr copy(::Float32) -> mpfr_set_flt
+@make_mpfr copy(::Float64) -> mpfr_set_d
+@make_mpfr copy(x::Float16) -> mpfr_set_flt pre=(x = Float32(x))
 
 operate!(::typeof(copy), x::BigFloat) = x
 
@@ -163,6 +166,7 @@ operate!(::typeof(one), x::BigFloat) = operate_to!(x, copy, 1)
 @make_mpfr +(::BigFloat, ::BigFloat) -> mpfr_add
 @make_mpfr +(::BigFloat, ::_MPFRMachineSigned) -> mpfr_add_si
 @make_mpfr +(::BigFloat, ::_MPFRMachineUnsigned) -> mpfr_add_ui
+@make_mpfr +(::BigFloat, ::_MPFRMachineFloat) -> mpfr_add_d
 
 operate_to!(out::BigFloat, ::typeof(+), a::Union{BigFloat,_MPFRMachineNumber}) = operate_to!(out, copy, a)
 
@@ -173,8 +177,10 @@ operate!(::typeof(+), a::BigFloat) = a
 @make_mpfr -(::BigFloat, ::BigFloat) -> mpfr_sub
 @make_mpfr -(::BigFloat, ::_MPFRMachineSigned) -> mpfr_sub_si
 @make_mpfr -(::BigFloat, ::_MPFRMachineUnsigned) -> mpfr_sub_ui
+@make_mpfr -(::BigFloat, ::_MPFRMachineFloat) -> mpfr_sub_d
 @make_mpfr -(::_MPFRMachineSigned, ::BigFloat) -> mpfr_si_sub
 @make_mpfr -(::_MPFRMachineUnsigned, ::BigFloat) -> mpfr_ui_sub
+@make_mpfr -(::_MPFRMachineFloat, ::BigFloat) -> mpfr_d_sub
 
 promote_operation(::typeof(-), ::Type{BigFloat}) = BigFloat
 
@@ -205,6 +211,7 @@ end
 @make_mpfr *(::BigFloat, ::BigFloat) -> mpfr_mul
 @make_mpfr *(::BigFloat, ::_MPFRMachineSigned) -> mpfr_mul_si
 @make_mpfr *(::BigFloat, ::_MPFRMachineUnsigned) -> mpfr_mul_ui
+@make_mpfr *(::BigFloat, ::_MPFRMachineFloat) -> mpfr_mul_d
 
 operate_to!(out::BigFloat, ::typeof(*), a::Union{BigFloat,_MPFRMachineNumber}) = operate_to!(out, copy, a)
 
@@ -215,8 +222,10 @@ operate!(::typeof(*), a::BigFloat) = a
 @make_mpfr /(::BigFloat, ::BigFloat) -> mpfr_div
 @make_mpfr /(::BigFloat, ::_MPFRMachineSigned) -> mpfr_div_si
 @make_mpfr /(::BigFloat, ::_MPFRMachineUnsigned) -> mpfr_div_ui
+@make_mpfr /(::BigFloat, ::_MPFRMachineFloat) -> mpfr_div_d
 @make_mpfr /(::_MPFRMachineSigned, ::BigFloat) -> mpfr_si_div
 @make_mpfr /(::_MPFRMachineUnsigned, ::BigFloat) -> mpfr_ui_div
+@make_mpfr /(::_MPFRMachineFloat, ::BigFloat) -> mpfr_d_div
 
 # roots
 @make_mpfr sqrt(::BigFloat) -> mpfr_sqrt

--- a/src/implementations/BigFloat.jl
+++ b/src/implementations/BigFloat.jl
@@ -328,7 +328,7 @@ end
 @make_mpfr_noround round(::BigFloat, ::RoundingMode{:ToZero}) -> mpfr_trunc
 @make_mpfr_noround round(::BigFloat, ::RoundingMode{:NearestTiesAway}) -> mpfr_round
 
-@make_mpfr modf(::BigFloat)::Tuple{BigFloat,BigFloat} -> mpfr_modf
+@make_mpfr modf(::BigFloat)::Tuple{BigFloat,BigFloat} -> mpfr_modf pre=(out = reverse(out)) post=(out = reverse(out))
 @make_mpfr rem(::BigFloat, ::BigFloat) -> mpfr_fmod
 @make_mpfr rem(::BigFloat, ::BigFloat, ::RoundingMode{:Nearest}) -> mpfr_remainder
 

--- a/src/implementations/BigFloat.jl
+++ b/src/implementations/BigFloat.jl
@@ -168,7 +168,7 @@ operate!(::typeof(one), x::BigFloat) = operate_to!(x, copy, 1)
 @make_mpfr +(::BigFloat, ::_MPFRMachineUnsigned) -> mpfr_add_ui
 @make_mpfr +(::BigFloat, ::_MPFRMachineFloat) -> mpfr_add_d
 
-operate_to!(out::BigFloat, ::typeof(+), a::Union{BigFloat,_MPFRMachineNumber}) = operate_to!(out, copy, a)
+operate_to!(out::BigFloat, ::typeof(+), a::Real) = operate_to!(out, copy, a)
 
 operate!(::typeof(+), a::BigFloat) = a
 
@@ -189,7 +189,7 @@ function operate!(::typeof(-), x::BigFloat)
     return x
 end
 
-function operate_to!(o::BigFloat, ::typeof(-), x::Union{BigFloat,_MPFRMachineNumber})
+function operate_to!(o::BigFloat, ::typeof(-), x::Real)
     operate_to!(o, copy, x)
     return operate!(-, o)
 end
@@ -201,7 +201,7 @@ function operate!(::typeof(abs), x::BigFloat)
     return x
 end
 
-function operate_to!(o::BigFloat, ::typeof(abs), x::Union{BigFloat,_MPFRMachineNumber})
+function operate_to!(o::BigFloat, ::typeof(abs), x::Real)
     operate_to!(o, copy, x)
     return operate!(abs, o)
 end
@@ -213,7 +213,7 @@ end
 @make_mpfr *(::BigFloat, ::_MPFRMachineUnsigned) -> mpfr_mul_ui
 @make_mpfr *(::BigFloat, ::_MPFRMachineFloat) -> mpfr_mul_d
 
-operate_to!(out::BigFloat, ::typeof(*), a::Union{BigFloat,_MPFRMachineNumber}) = operate_to!(out, copy, a)
+operate_to!(out::BigFloat, ::typeof(*), a::Real) = operate_to!(out, copy, a)
 
 operate!(::typeof(*), a::BigFloat) = a
 
@@ -348,8 +348,8 @@ function operate_to!(
     output::BigFloat,
     op::Union{typeof(+),typeof(-),typeof(*)},
     a::BigFloat,
-    b::Union{BigFloat,_MPFRMachineNumber},
-    c::Vararg{Union{BigFloat,_MPFRMachineNumber},N},
+    b::Real,
+    c::Vararg{Real,N},
 ) where {N}
     operate_to!(output, op, a, b)
     return operate!(op, output, c...)

--- a/test/bigfloat_wrappers.jl
+++ b/test/bigfloat_wrappers.jl
@@ -1,0 +1,161 @@
+@testset "MPFR wrappers" begin
+    # call MA.operate_to!(out, op, args...) and compare with expected. If Base throws for
+    # the inputs, assert MA throws the same kind of error.
+    function check_op_matches_expected(op, args...; out=BigFloat(), expected=missing)
+        # preserve originals for mutation checks
+        old_args = MA.copy_if_mutable.(args)
+
+        # Test operate_to! into an output
+        local result
+        success = try
+            result = MA.operate_to!(out, op, args...)
+            true
+        catch e
+            @test_throws typeof(e) op(args...)
+            false
+        end
+        if success
+            @test result === out # check return value
+            if ismissing(expected)
+                success = try
+                    expected = op(args...)
+                    true
+                catch e
+                    @test false
+                    false
+                end
+            end
+            if success
+                if out isa Real
+                    @test out ≈ expected atol=1e-13
+                else
+                    @test length(out) == length(expected)
+                    for (outᵢ, expectedᵢ) in zip(out, expected)
+                        @test outᵢ ≈ expectedᵢ atol=1e-13
+                    end
+                end
+            end
+        end
+
+        # Ensure operate_to! didn't mutate the input arguments
+        @test old_args == args
+    end
+
+    setprecision(BigFloat, 64) do
+        check_op_matches_expected(copy, big"12.")
+        check_op_matches_expected(copy, -12)
+        check_op_matches_expected(copy, UInt(12))
+        check_op_matches_expected(copy, 12f0)
+        check_op_matches_expected(copy, 12.)
+
+        check_op_matches_expected(ldexp, -5, 3; expected=ldexp(-5., 3))
+        check_op_matches_expected(ldexp, UInt(5), 3; expected=ldexp(5., 3))
+        check_op_matches_expected(ldexp, big"5.", -3)
+        check_op_matches_expected(ldexp, big"5.", UInt(3))
+
+        check_op_matches_expected(+, big"1.5", big"2.5")
+        check_op_matches_expected(+, big"1.5", 10)
+        check_op_matches_expected(+, big"1.5", 0x23)
+        check_op_matches_expected(+, big"1.5", 2.5)
+        check_op_matches_expected(+, big"1.5", 2.5f0)
+
+        check_op_matches_expected(-, big"1.5", big"2.5")
+        check_op_matches_expected(-, big"1.5", Int32(-42))
+        check_op_matches_expected(-, big"1.5", 0x6525)
+        check_op_matches_expected(-, big"1.5", 17.)
+        check_op_matches_expected(-, Int16(-62), big"1.5")
+        check_op_matches_expected(-, 0x73764fa, big"1.5")
+        check_op_matches_expected(-, 24., big"1.5")
+
+        check_op_matches_expected(*, big"63.6", big"91.")
+        check_op_matches_expected(*, big"63.6", Int32(-52))
+        check_op_matches_expected(*, big"63.6", 0x53d2a)
+        check_op_matches_expected(*, big"63.6", 8f3)
+
+        for dividend in (58, 0)
+            check_op_matches_expected(/, big"5352.5", BigFloat(dividend))
+            check_op_matches_expected(/, big"5352.5", Int(dividend))
+            check_op_matches_expected(/, big"5352.5", UInt(dividend))
+            check_op_matches_expected(/, big"5352.5", Float64(dividend))
+            check_op_matches_expected(/, 5352, BigFloat(dividend))
+            check_op_matches_expected(/, 0x452, BigFloat(dividend))
+            check_op_matches_expected(/, 5352.5, BigFloat(dividend))
+        end
+
+        check_op_matches_expected(sqrt, big"646.4")
+        check_op_matches_expected(sqrt, 0x16)
+        check_op_matches_expected(cbrt, big"652.6")
+        @isdefined(fourthroot) && check_op_matches_expected(fourthroot, big"746.3")
+
+        check_op_matches_expected(factorial, 0x12)
+
+        check_op_matches_expected(fma, big"1.2", big"2.3", big"0.7")
+
+        check_op_matches_expected(hypot, big"3.", big"4.")
+
+        check_op_matches_expected(log, big"2.5")
+        check_op_matches_expected(log, big"-53.")
+        check_op_matches_expected(log, 0x623)
+        check_op_matches_expected(log, 0x0)
+        check_op_matches_expected(log2, big"8.0")
+        check_op_matches_expected(log2, big"0.")
+        check_op_matches_expected(log10, big"100.0")
+        check_op_matches_expected(log10, big"-17.")
+        check_op_matches_expected(log1p, big"0.001")
+        check_op_matches_expected(log1p, big"-13.")
+
+        check_op_matches_expected(exp, big"1.2")
+        check_op_matches_expected(exp2, big"3.0")
+        check_op_matches_expected(exp10, big"2.0")
+        check_op_matches_expected(expm1, big"0.001")
+
+        check_op_matches_expected(^, big"17.", big"13.")
+        check_op_matches_expected(^, big"17.", 13)
+        check_op_matches_expected(^, big"17.", 0x13)
+
+        check_op_matches_expected(cos, big"0.5")
+        check_op_matches_expected(sin, big"0.5")
+        check_op_matches_expected(tan, big"0.5")
+        check_op_matches_expected(cospi, big"0.5")
+        check_op_matches_expected(sinpi, big"0.5")
+        check_op_matches_expected(tanpi, big"0.125")
+        check_op_matches_expected(tanpi, big"0.5")
+        check_op_matches_expected(cosd, big"60.0")
+        check_op_matches_expected(sind, big"30.0")
+        check_op_matches_expected(tand, big"30.0")
+        check_op_matches_expected(tand, big"90.")
+        check_op_matches_expected(sincos, big"0.5"; out=(BigFloat(), BigFloat()))
+        check_op_matches_expected(sec, big"0.7")
+        check_op_matches_expected(csc, big"0.7")
+        check_op_matches_expected(cot, big"0.7")
+        check_op_matches_expected(acos, big"0.5")
+        check_op_matches_expected(asin, big"0.5")
+        check_op_matches_expected(atan, big"0.5")
+        check_op_matches_expected(atan, big"0.5", big"0.9")
+        check_op_matches_expected(acosd, big"0.5")
+        check_op_matches_expected(asind, big"0.5")
+        check_op_matches_expected(atand, big"0.5")
+        check_op_matches_expected(atand, big"0.5", big"0.9")
+
+        check_op_matches_expected(cosh, big"0.5")
+        check_op_matches_expected(sinh, big"0.5")
+        check_op_matches_expected(tanh, big"0.5")
+        check_op_matches_expected(sech, big"0.5")
+        check_op_matches_expected(csch, big"0.5")
+        check_op_matches_expected(coth, big"0.5")
+        check_op_matches_expected(acosh, big"2.0")
+        check_op_matches_expected(asinh, big"0.5")
+        check_op_matches_expected(atanh, big"0.3")
+
+        for rm in (RoundNearest, RoundUp, RoundDown, RoundToZero, RoundNearestTiesAway)
+            check_op_matches_expected(round, big"24.", rm)
+        end
+
+        check_op_matches_expected(modf, big"3.1415"; out=(BigFloat(), BigFloat()))
+        check_op_matches_expected(rem, big"7.5", big"2.3")
+        check_op_matches_expected(rem, big"7.5", big"2.3", RoundNearest)
+        check_op_matches_expected(min, big"1.2", big"2.3")
+        check_op_matches_expected(max, big"1.2", big"2.3")
+        check_op_matches_expected(copysign, big"-1.2", big"2.0")
+    end
+end

--- a/test/bigfloat_wrappers.jl
+++ b/test/bigfloat_wrappers.jl
@@ -85,7 +85,7 @@
         check_op_matches_expected(sqrt, big"646.4")
         check_op_matches_expected(sqrt, 0x16)
         check_op_matches_expected(cbrt, big"652.6")
-        @isdefined(fourthroot) && check_op_matches_expected(fourthroot, big"746.3")
+        VERSION ≥ v"1.10" && check_op_matches_expected(fourthroot, big"746.3")
 
         check_op_matches_expected(factorial, 0x12)
 
@@ -116,14 +116,16 @@
         check_op_matches_expected(cos, big"0.5")
         check_op_matches_expected(sin, big"0.5")
         check_op_matches_expected(tan, big"0.5")
-        check_op_matches_expected(cospi, big"0.5")
-        check_op_matches_expected(sinpi, big"0.5")
-        check_op_matches_expected(tanpi, big"0.125")
-        check_op_matches_expected(tanpi, big"0.5")
-        check_op_matches_expected(cosd, big"60.0")
-        check_op_matches_expected(sind, big"30.0")
-        check_op_matches_expected(tand, big"30.0")
-        check_op_matches_expected(tand, big"90.")
+        if VERSION ≥ v"1.10"
+            check_op_matches_expected(cospi, big"0.5")
+            check_op_matches_expected(sinpi, big"0.5")
+            check_op_matches_expected(tanpi, big"0.125")
+            check_op_matches_expected(tanpi, big"0.5")
+            check_op_matches_expected(cosd, big"60.0")
+            check_op_matches_expected(sind, big"30.0")
+            check_op_matches_expected(tand, big"30.0")
+            check_op_matches_expected(tand, big"90.")
+        end
         check_op_matches_expected(sincos, big"0.5"; out=(BigFloat(), BigFloat()))
         check_op_matches_expected(sec, big"0.7")
         check_op_matches_expected(csc, big"0.7")
@@ -132,10 +134,12 @@
         check_op_matches_expected(asin, big"0.5")
         check_op_matches_expected(atan, big"0.5")
         check_op_matches_expected(atan, big"0.5", big"0.9")
-        check_op_matches_expected(acosd, big"0.5")
-        check_op_matches_expected(asind, big"0.5")
-        check_op_matches_expected(atand, big"0.5")
-        check_op_matches_expected(atand, big"0.5", big"0.9")
+        if VERSION ≥ v"1.10"
+            check_op_matches_expected(acosd, big"0.5")
+            check_op_matches_expected(asind, big"0.5")
+            check_op_matches_expected(atand, big"0.5")
+            check_op_matches_expected(atand, big"0.5", big"0.9")
+        end
 
         check_op_matches_expected(cosh, big"0.5")
         check_op_matches_expected(sinh, big"0.5")

--- a/test/bigfloat_wrappers.jl
+++ b/test/bigfloat_wrappers.jl
@@ -1,7 +1,12 @@
 @testset "MPFR wrappers" begin
     # call MA.operate_to!(out, op, args...) and compare with expected. If Base throws for
     # the inputs, assert MA throws the same kind of error.
-    function check_op_matches_expected(op, args...; out=BigFloat(), expected=missing)
+    function check_op_matches_expected(
+        op,
+        args...;
+        out = BigFloat(),
+        expected = missing,
+    )
         # preserve originals for mutation checks
         old_args = MA.copy_if_mutable.(args)
 
@@ -45,11 +50,11 @@
         check_op_matches_expected(copy, big"12.")
         check_op_matches_expected(copy, -12)
         check_op_matches_expected(copy, UInt(12))
-        check_op_matches_expected(copy, 12f0)
-        check_op_matches_expected(copy, 12.)
+        check_op_matches_expected(copy, 12.0f0)
+        check_op_matches_expected(copy, 12.0)
 
-        check_op_matches_expected(ldexp, -5, 3; expected=ldexp(-5., 3))
-        check_op_matches_expected(ldexp, UInt(5), 3; expected=ldexp(5., 3))
+        check_op_matches_expected(ldexp, -5, 3; expected = ldexp(-5.0, 3))
+        check_op_matches_expected(ldexp, UInt(5), 3; expected = ldexp(5.0, 3))
         check_op_matches_expected(ldexp, big"5.", -3)
         check_op_matches_expected(ldexp, big"5.", UInt(3))
 
@@ -62,15 +67,15 @@
         check_op_matches_expected(-, big"1.5", big"2.5")
         check_op_matches_expected(-, big"1.5", Int32(-42))
         check_op_matches_expected(-, big"1.5", 0x6525)
-        check_op_matches_expected(-, big"1.5", 17.)
+        check_op_matches_expected(-, big"1.5", 17.0)
         check_op_matches_expected(-, Int16(-62), big"1.5")
         check_op_matches_expected(-, 0x73764fa, big"1.5")
-        check_op_matches_expected(-, 24., big"1.5")
+        check_op_matches_expected(-, 24.0, big"1.5")
 
         check_op_matches_expected(*, big"63.6", big"91.")
         check_op_matches_expected(*, big"63.6", Int32(-52))
         check_op_matches_expected(*, big"63.6", 0x53d2a)
-        check_op_matches_expected(*, big"63.6", 8f3)
+        check_op_matches_expected(*, big"63.6", 8.0f3)
 
         for dividend in (58, 0)
             check_op_matches_expected(/, big"5352.5", BigFloat(dividend))
@@ -126,7 +131,11 @@
             check_op_matches_expected(tand, big"30.0")
             check_op_matches_expected(tand, big"90.")
         end
-        check_op_matches_expected(sincos, big"0.5"; out=(BigFloat(), BigFloat()))
+        check_op_matches_expected(
+            sincos,
+            big"0.5";
+            out = (BigFloat(), BigFloat()),
+        )
         check_op_matches_expected(sec, big"0.7")
         check_op_matches_expected(csc, big"0.7")
         check_op_matches_expected(cot, big"0.7")
@@ -151,15 +160,25 @@
         check_op_matches_expected(asinh, big"0.5")
         check_op_matches_expected(atanh, big"0.3")
 
-        for rm in (RoundNearest, RoundUp, RoundDown, RoundToZero, RoundNearestTiesAway)
+        for rm in (
+            RoundNearest,
+            RoundUp,
+            RoundDown,
+            RoundToZero,
+            RoundNearestTiesAway,
+        )
             check_op_matches_expected(round, big"24.", rm)
         end
 
-        check_op_matches_expected(modf, big"3.1415"; out=(BigFloat(), BigFloat()))
+        check_op_matches_expected(
+            modf,
+            big"3.1415";
+            out = (BigFloat(), BigFloat()),
+        )
         check_op_matches_expected(rem, big"7.5", big"2.3")
         check_op_matches_expected(rem, big"7.5", big"2.3", RoundNearest)
         check_op_matches_expected(min, big"1.2", big"2.3")
         check_op_matches_expected(max, big"1.2", big"2.3")
-        check_op_matches_expected(copysign, big"-1.2", big"2.0")
+        return check_op_matches_expected(copysign, big"-1.2", big"2.0")
     end
 end

--- a/test/bigfloat_wrappers.jl
+++ b/test/bigfloat_wrappers.jl
@@ -83,11 +83,11 @@
         end
 
         check_op_matches_expected(sqrt, big"646.4")
-        check_op_matches_expected(sqrt, 0x16)
+        check_op_matches_expected(sqrt, 0x12)
         check_op_matches_expected(cbrt, big"652.6")
         VERSION ≥ v"1.10" && check_op_matches_expected(fourthroot, big"746.3")
 
-        check_op_matches_expected(factorial, 0x12)
+        check_op_matches_expected(factorial, 0xc)
 
         check_op_matches_expected(fma, big"1.2", big"2.3", big"0.7")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,9 @@ end
 @testset "BigFloat dot" begin
     include("bigfloat_dot.jl")
 end
+@testset "BigFloat all wrappers" begin
+    include("bigfloat_wrappers.jl")
+end
 @testset "evalpoly" begin
     include("evalpoly.jl")
 end


### PR DESCRIPTION
I recently saw that MutableArithmetics does not support most of the functions that MPFR offers, only the basic arithmetic and assignment stuff. Actually, I needed it for assignment of (bit) integer values, but when I looked at it, I thought that just implementing the whole bunch of functions is not much more effort once you have a nice macro to automate it.
So in this PR:
- I implement a macro that creates the function wrappers, replacing the manual repetitive wrappers
- I rewrite all existing MPFR functions to use this macro
- I implement most or perhaps even all of the standard functions (i.e., functions that Julia's BigFloat implementation already knows without mutation), where I follow the order of the MPFR documentation

However:
- There are no tests for this yet (but the existing ones are not broken) - first I would like to know whether you are interested in this functionality at all or whether you think it is too much? After all, the package is called "arithmetics," which you could in a strict sense say is a bit narrower than what this PR does.
- It would make sense to extend this approach to BigInt, which also has a couple more functions that could be implemented, and also some functions that are at the intersection of GMP and MPFR (setting MPFR Floats from GMP Ints).
- It would also make sense to include a package extension for `SpecialFunctions.jl` and implement the functions from there that are part of MPFR.

If you want this to proceed, I think tests should be part of this PR, but the other two points could also be separate...