### PR TITLE
Narrow Zero arithmetic methods to reduce invalidations

### DIFF
--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -13,6 +13,16 @@
 
 abstract type AbstractMutable end
 
+# Zero arithmetic methods for AbstractMutable types.
+# The main Zero arithmetic is defined in rewrite.jl with Number/AbstractArray;
+# these methods extend it to AbstractMutable.
+Base.:*(z::Zero, ::AbstractMutable) = z
+Base.:*(::AbstractMutable, z::Zero) = z
+Base.:+(::Zero, x::AbstractMutable) = copy_if_mutable(x)
+Base.:+(x::AbstractMutable, ::Zero) = copy_if_mutable(x)
+Base.:-(::Zero, x::AbstractMutable) = operate(-, x)
+Base.:-(x::AbstractMutable, ::Zero) = copy_if_mutable(x)
+
 function Base.sum(
     a::AbstractArray{T};
     dims = :,

--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -58,20 +58,31 @@ broadcast!!(::Union{typeof(add_mul),typeof(+)}, ::Zero, x) = copy_if_mutable(x)
 broadcast!!(::typeof(add_mul), ::Zero, x, y) = x * y
 
 # Needed in `@rewrite(1 .+ sum(1 for i in 1:0) * 1^2)`
-Base.:*(z::Zero, ::Any) = z
-Base.:*(::Any, z::Zero) = z
+# These methods are narrowed to `Number` and `AbstractArray` to avoid invalidating
+# the very broad `+(x, y)`, `*(x, y)` fallbacks in Base, which causes thousands of
+# method invalidations across the ecosystem. Downstream packages that define custom
+# types participating in MutableArithmetics rewrites should define their own
+# `+(::MyType, ::Zero)` etc. methods.
+Base.:*(z::Zero, ::Number) = z
+Base.:*(::Number, z::Zero) = z
+Base.:*(z::Zero, ::AbstractArray) = z
+Base.:*(::AbstractArray, z::Zero) = z
 Base.:*(z::Zero, ::Zero) = z
-Base.:+(::Zero, x::Any) = x
-Base.:+(x::Any, ::Zero) = x
+Base.:+(::Zero, x::Number) = x
+Base.:+(x::Number, ::Zero) = x
+Base.:+(::Zero, x::AbstractArray) = x
+Base.:+(x::AbstractArray, ::Zero) = x
 Base.:+(z::Zero, ::Zero) = z
-Base.:-(::Zero, x::Any) = -x
-Base.:-(x::Any, ::Zero) = x
+Base.:-(::Zero, x::Number) = -x
+Base.:-(x::Number, ::Zero) = x
+Base.:-(::Zero, x::AbstractArray) = -x
+Base.:-(x::AbstractArray, ::Zero) = x
 Base.:-(z::Zero, ::Zero) = z
 Base.:-(z::Zero) = z
 Base.:+(z::Zero) = z
 Base.:*(z::Zero) = z
 
-function Base.:/(z::Zero, x::Any)
+function Base.:/(z::Zero, x::Number)
     if iszero(x)
         throw(DivideError())
     else


### PR DESCRIPTION
## Summary
- Narrow `+(x::Any, ::Zero)`, `*(::Zero, ::Any)`, `-(x::Any, ::Zero)`,
  and `/(::Zero, x::Any)` from `::Any` to `Number`, `AbstractArray`, and `AbstractMutable`
- Moves `AbstractMutable` methods to `dispatch.jl` (where the type is defined)
- All existing tests pass

## Motivation

Loading MutableArithmetics causes **1,489 method invalidations**. After this PR: **1,317** (-172).

The remaining MA-owned invalidations (462) are from `MutatingStepRange <: OrdinalRange` which is inherent to subtyping `OrdinalRange` and not addressable by type narrowing. The rest (855) come from SparseArrays/Test stdlibs.

### Before (v1.6.7 released)

| Method | Invalidations |
|---|---|
| `+(x::Any, ::Zero)` | 446 |
| `step(r::MutatingStepRange)` | 429 |
| `*(::Zero, ::Any)` | 56 |
| `iterate(r::MutatingStepRange, i)` | 30 |

### After (this PR)

| Method | Invalidations |
|---|---|
| `step(r::MutatingStepRange)` | 429 (unchanged — inherent to OrdinalRange subtyping) |
| `iterate(r::MutatingStepRange, i)` | 30 (unchanged) |
| `+(x::Number, ::Zero)` | 0 |
| `*(::Number, z::Zero)` | 0 |

The Zero `+`/`*`/`-`/`/` invalidations are fully eliminated by this PR. The `MutatingStepRange` invalidations remain but are a separate issue.

## How to reproduce

In a fresh Julia session:
```julia
using SnoopCompileCore
invs = @snoop_invalidations begin
    using MutableArithmetics
end
using SnoopCompile
using SnoopCompile: countchildren
trees = invalidation_trees(invs)
trees = filter(t -> countchildren(t) > 0, trees)
sort!(trees; by=countchildren, rev=true)
println("Total invalidated methods: ", sum(countchildren, trees))
for t in trees
    println("  $(countchildren(t)) children — ", t)
end
```

## Test plan
- [x] All existing MutableArithmetics tests pass
- [x] Invalidation count verified with SnoopCompile before/after