### PR TITLE
Fix /(::Zero, ::AbstractMutable)

### DIFF
--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -23,6 +23,13 @@ Base.:+(x::AbstractMutable, ::Zero) = copy_if_mutable(x)
 Base.:-(::Zero, x::AbstractMutable) = operate(-, x)
 Base.:-(x::AbstractMutable, ::Zero) = copy_if_mutable(x)
 
+function Base.:/(z::Zero, x::AbstractMutable)
+    if iszero(x)
+        throw(DivideError())
+    end
+    return z
+end
+
 function Base.sum(
     a::AbstractArray{T};
     dims = :,

--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -85,9 +85,8 @@ Base.:*(z::Zero) = z
 function Base.:/(z::Zero, x::Number)
     if iszero(x)
         throw(DivideError())
-    else
-        return z
     end
+    return z
 end
 
 Base.iszero(::Zero) = true

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -546,6 +546,12 @@ function test_operate()
     return
 end
 
+function test_op_divide()
+    @test MA.Zero() / DummyBigInt(1) == MA.Zero()
+    @test_throws DivideError MA.Zero() / DummyBigInt(0)
+    return
+end
+
 end  # TestBasics
 
 TestBasics.runtests()


### PR DESCRIPTION
Caused by https://github.com/jump-dev/MutableArithmetics.jl/pull/348

This broke PowerModels.